### PR TITLE
[SP-039] Implement Manual Build Trigger via UI and API URL

### DIFF
--- a/web/app/api/builds/trigger/route.ts
+++ b/web/app/api/builds/trigger/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+
+import { triggerBuildApi } from '@/features/builds/actions'
+
+export async function POST(request: Request) {
+  const payload = await request.json()
+
+  if (!payload.projectToken || !payload.projectId || !payload.buildIdentifier) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Field projectId, projectToken and buildIdentifier are required.',
+      },
+      { status: 400 },
+    )
+  }
+
+  const build = await triggerBuildApi({
+    projectId: payload.projectId,
+    identifier: payload.buildIdentifier,
+    token: payload.projectToken,
+  })
+
+  return build
+}

--- a/web/features/builds/actions.ts
+++ b/web/features/builds/actions.ts
@@ -3,6 +3,7 @@
 import { type Subscriber } from '@novu/js'
 import { and, asc, count, desc, eq, like, type SQL } from 'drizzle-orm'
 import { type Route } from 'next'
+import { NextResponse } from 'next/server'
 
 import { APP_URL } from '@/constants/env'
 import { NOVU_WORKFLOW_BUILD_CREATED } from '@/constants/novu'
@@ -68,6 +69,16 @@ export async function triggerBuild({ projectId, identifier }: { projectId: strin
     return { ok: false, error: 'Project not found' } as const
   }
 
+  const [pendingBuilds] = await db
+    .select()
+    .from(builds)
+    .where(and(eq(builds.projectId, projectId), eq(builds.status, BuildStatus.pending)))
+    .limit(1)
+
+  if (pendingBuilds) {
+    return { ok: false, error: 'Pending build still exists!' } as const
+  }
+
   const safeIdentifier = identifier?.trim()
   const buildIdentifier =
     safeIdentifier && safeIdentifier.length > 0 ? safeIdentifier : `manual-${humanReadableEpoch()}`
@@ -124,4 +135,36 @@ export async function getBuildDetail({ projectId, buildId }: { projectId: string
   if (!build) return null
 
   return build
+}
+
+export async function triggerBuildApi({
+  projectId,
+  identifier,
+  token,
+}: {
+  projectId: string
+  identifier: string
+  token: string
+}) {
+  const [project] = await db
+    .select()
+    .from(projects)
+    .where(and(eq(projects.id, projectId), eq(projects.token, token)))
+    .limit(1)
+
+  if (!project) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Invalid project id or token',
+      },
+      { status: 400 },
+    )
+  }
+
+  const build = await triggerBuild({ projectId, identifier })
+  if (!build.ok) {
+    return NextResponse.json(build, { status: 401 })
+  }
+  return NextResponse.json(build, { status: 201 })
 }


### PR DESCRIPTION
## [SP-039] Implement Manual Build Trigger via UI and API URL

## Summary

Implement manual build trigger via ui and api url

## Changes

- create api for trigger via api
- add validation for pending builds when manually triggered via the UI.

## Testing

- Trigger build via button in builds page
- post api to `/api/builds/trigger` with body: projectId, projectToken, buildIdentifier

## Screenshots

Manual trigger
<img width="3370" height="1138" alt="image" src="https://github.com/user-attachments/assets/ce0dd60a-e6ee-4c79-bbf1-94807fe967a5" />

Trigger via API
<img width="1422" height="894" alt="image" src="https://github.com/user-attachments/assets/d32defc1-672d-493f-9a2c-a804e1a20a73" />
