### PR TITLE
Fix temporal production error

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -15,15 +15,15 @@ services:
       - "${WEBAPP_PORT:-18000}:3000"
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://0.0.0.0:3000"]
-      interval: 10s
+      interval: 3s
       timeout: 5s
-      retries: 15
+      retries: 30
     env_file: [".env"]
     depends_on:
       postgres-webapp:
         condition: "service_healthy"
     volumes:
-      - "webapp_logs:/app/logs"
+      - "./web/logs:/app/logs"
   webapp-migration-runner:
     build:
       context: "web"
@@ -49,11 +49,13 @@ services:
       dockerfile: "Dockerfile.worker"
     env_file: [".env"]
     depends_on:
+      postgres-webapp:
+        condition: "service_healthy"
       temporal:
         condition: "service_healthy"
     volumes:
       - "webapp-worker_storage:/storage"
-      - "webapp_logs:/app/logs"
+      - "./web/logs:/app/logs"
   postgres-webapp:
     image: "postgres:18.1-alpine"
     environment:
@@ -62,9 +64,9 @@ services:
       POSTGRES_DB: "${DB_NAME:-}"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-} -d ${DB_NAME:-}"]
-      interval: 10s
+      interval: 3s
       timeout: 5s
-      retries: 15
+      retries: 30
     volumes:
       - "postgres-webapp_data:/var/lib/postgresql"
   postgres-temporal:
@@ -75,9 +77,9 @@ services:
       POSTGRES_DB: "temporal"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U temporal -d temporal"]
-      interval: 10s
+      interval: 3s
       timeout: 5s
-      retries: 15
+      retries: 30
     volumes:
       - "postgres-temporal_data:/var/lib/postgresql"
   temporal:
@@ -92,9 +94,9 @@ services:
       TEMPORAL_CLI_ADDRESS: "temporal:7233"
     healthcheck:
       test: ["CMD-SHELL", "temporal operator cluster health"]
-      interval: 10s
+      interval: 3s
       timeout: 5s
-      retries: 15
+      retries: 30
     depends_on:
       postgres-temporal:
         condition: "service_healthy"
@@ -104,6 +106,7 @@ services:
       TEMPORAL_ADDRESS: "temporal:7233"
       TEMPORAL_CORS_ORIGINS: "http://localhost:8233"
       TEMPORAL_UI_PORT: "8233"
+      TEMPORAL_HIDE_LOGS: "true" # Don't re-print logs from Temporal service
     ports:
       - "${TEMPORAL_UI_PORT:-18001}:8233"
     healthcheck:
@@ -124,7 +127,7 @@ services:
       RUSTFS_ADDRESS: "0.0.0.0:9000"
       RUSTFS_CONSOLE_ADDRESS: "0.0.0.0:9001"
       RUSTFS_CONSOLE_ENABLE: true
-      RUSTFS_EXTERNAL_ADDRESS: ":18002"
+      RUSTFS_EXTERNAL_ADDRESS: ":${RUSTFS_PORT:-18002}"
       RUSTFS_CORS_ALLOWED_ORIGINS: "*"
       RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS: "*"
       RUSTFS_ACCESS_KEY: "${RUSTFS_INITIAL_ACCESS_KEY:-}"
@@ -144,10 +147,9 @@ services:
           "CMD-SHELL",
           "curl -f http://localhost:9000/health && curl -f http://localhost:9001/rustfs/console/health",
         ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
+      interval: 3s
+      timeout: 5s
+      retries: 30
   # RustFS volume permissions fixer service
   rustfs-volume-permission-helper:
     image: "alpine"
@@ -200,4 +202,3 @@ volumes:
   rustfs_data:
   rustfs_logs:
   webapp-worker_storage:
-  webapp_logs:

--- a/compose.yml
+++ b/compose.yml
@@ -14,7 +14,10 @@ services:
     ports:
       - "${WEBAPP_PORT:-18000}:3000"
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider http://0.0.0.0:3000 || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS http://0.0.0.0:3000"]
+      interval: 10s
+      timeout: 5s
+      retries: 15
     env_file: [".env"]
     depends_on:
       postgres-webapp:
@@ -25,7 +28,7 @@ services:
     build:
       context: "web"
       dockerfile: "Dockerfile"
-      target: "builder"
+      target: "development"
       args:
         NEXT_PUBLIC_NOVU_APP_IDENTIFIER: ${NEXT_PUBLIC_NOVU_APP_IDENTIFIER:-}
         NEXT_PUBLIC_NOVU_BACKEND_URL: ${NEXT_PUBLIC_NOVU_BACKEND_URL:-}

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -6,14 +6,14 @@ vars:
   DOCKER_COMPOSE_SCRIPT:
     sh: |
       if [ "{{.APP_ENV}}" = "development" ]; then
-        echo "docker compose -f compose.yml -f compose.dev.yml"
+        echo "docker compose -f compose.yml -f compose.dev.yml{{ if eq .FILESYSTEM_DISK "rustfs" }} --profile rustfs{{ end }}{{if eq .USE_EXTERNAL_SELENIUM "false"}} --profile selenium{{ end }}"
       else
-        echo "docker compose -f compose.yml"
+        echo "docker compose -f compose.yml{{ if eq .FILESYSTEM_DISK "rustfs" }} --profile rustfs{{ end }}{{if eq .USE_EXTERNAL_SELENIUM "false"}} --profile selenium{{ end }}"
       fi
 tasks:
   up:
     cmds:
-      - '{{.DOCKER_COMPOSE_SCRIPT}} {{ if eq .FILESYSTEM_DISK "rustfs" }}--profile rustfs{{ end }} {{if eq .USE_EXTERNAL_SELENIUM "false"}}--profile selenium{{ end }} up --detach --build --remove-orphans'
+      - "{{.DOCKER_COMPOSE_SCRIPT}} up --detach --build --remove-orphans"
       - task: "migrate"
   down:
     cmds:
@@ -32,7 +32,7 @@ tasks:
       - "{{.DOCKER_COMPOSE_SCRIPT}} exec postgres-webapp psql -U {{.DB_USER}} -d {{.DB_NAME}}"
   stop:
     cmds:
-      - '{{.DOCKER_COMPOSE_SCRIPT}} {{ if eq .FILESYSTEM_DISK "rustfs" }}--profile rustfs{{ end }} {{if eq .USE_EXTERNAL_SELENIUM "false"}}--profile selenium{{ end }} stop'
+      - "{{.DOCKER_COMPOSE_SCRIPT}} stop"
   migrate:
     cmds:
       - "{{.DOCKER_COMPOSE_SCRIPT}} run --build --rm webapp-migration-runner task migrate"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,22 +1,27 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv
 
-FROM node:24-alpine AS base
+ARG NODE_VERSION=24
+FROM node:${NODE_VERSION}-slim AS base
 
 # Install dependencies only when needed
 FROM base AS deps
 WORKDIR /app
 
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
 
-RUN sh -c "$(wget -qO- https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+apt-get install -y --no-install-recommends curl ca-certificates && \
+rm -rf /var/lib/apt/lists/*
+
+RUN sh -c "$(curl -fsSL https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 
 COPY package.json package-lock.json ./
 RUN npm ci
 
 
-FROM base AS development
+FROM deps AS development
 WORKDIR /app
 
 # Environment variables must be present at build time
@@ -43,11 +48,10 @@ ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
 # Install dev tools
-RUN apk add --no-cache git
-COPY --from=deps /usr/local/bin/task /usr/local/bin
-
-COPY package.json package-lock.json ./
-COPY --from=deps /app/node_modules ./node_modules
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install dev dependencies
 RUN npm install
@@ -91,7 +95,7 @@ COPY . .
 RUN npm run build
 
 
-FROM base AS production
+FROM node:${NODE_VERSION}-alpine AS production
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/web/lib/browser-engine/selenium.ts
+++ b/web/lib/browser-engine/selenium.ts
@@ -6,7 +6,6 @@ import firefox from 'selenium-webdriver/firefox'
 import { Browser } from '@/constants/enum'
 import { SELENIUM_REMOTE_URL } from '@/constants/env'
 import { SELENIUM_IMPLICIT_TIMEOUT, SELENIUM_PAGE_LOAD_TIMEOUT, SELENIUM_SCRIPT_TIMEOUT } from '@/constants/selenium'
-import { logger } from '@/lib/logger'
 import { type IBrowserEngine } from '@/types/browser-engine'
 import { type SnapshotPayload } from '@/types/screenshot'
 
@@ -151,10 +150,8 @@ export class SeleniumBrowserEngine implements IBrowserEngine {
   }
 
   public async waitForSelector(selector: string, timeout: number, dontThrow?: boolean): Promise<void> {
-    logger.info(`Waiting for selector: ${selector}`)
     await this.driver.wait(until.elementLocated(By.css(selector)), timeout).catch((err) => {
       if (dontThrow) {
-        logger.warn(`Selector ${selector} not found within ${timeout} ms, but continuing as dontThrow is set.`)
         return
       }
 

--- a/web/lib/logger.ts
+++ b/web/lib/logger.ts
@@ -8,6 +8,8 @@ export const logger = winston.createLogger({
   level: 'debug',
   format: combine(timestamp(), errors({ stack: true }), json()),
   transports: [
+    new winston.transports.Console(),
+
     new winston.transports.File({
       filename: 'logs/error.log',
       level: 'error',

--- a/web/temporal/activities/build.ts
+++ b/web/temporal/activities/build.ts
@@ -30,26 +30,34 @@ export async function markBuildAsStarted({ buildId }: { buildId: string }) {
     }
 
     await db.update(builds).set({ status: BuildStatus.IN_PROGRESS }).where(eq(builds.id, buildId))
-  } catch (err) {
-    if (err instanceof ApplicationFailure) {
-      throw err
+  } catch (error) {
+    if (error instanceof ApplicationFailure) {
+      throw error
     }
 
-    logger.error(err)
-    throw ApplicationFailure.retryable(`Failed to mark build as started: ${err instanceof Error ? err.message : err}`)
+    logger.error(error)
+    throw ApplicationFailure.retryable(
+      `Failed to mark build as started: ${error instanceof Error ? error.message : error}`,
+      error instanceof Error ? error.name : 'UnknownError',
+      [{ error }],
+    )
   }
 }
 
 export async function takeScreenshot(params: CaptureScreenshotParams): Promise<CaptureScreenshotResult> {
   try {
     return await new ScreenshotCapturer(params).capture()
-  } catch (err) {
-    if (err instanceof UnsupportedBrowserEngineError) {
-      throw ApplicationFailure.nonRetryable(err.message)
+  } catch (error) {
+    if (error instanceof UnsupportedBrowserEngineError) {
+      throw ApplicationFailure.nonRetryable(error.message, error.name)
     }
 
-    logger.error(err)
-    throw ApplicationFailure.retryable(`Failed to capture screenshot: ${err instanceof Error ? err.message : err}`)
+    logger.error(error)
+    throw ApplicationFailure.retryable(
+      `Failed to capture screenshot: ${error instanceof Error ? error.message : error}`,
+      error instanceof Error ? error.name : 'UnknownError',
+      [{ error }],
+    )
   }
 }
 
@@ -57,7 +65,7 @@ export async function processScreenshot(params: ProcessScreenshotParams): Promis
   try {
     fs.accessSync(params.tempPath, fs.constants.R_OK)
   } catch {
-    throw ApplicationFailure.nonRetryable(`Screenshot file not found: ${params.tempPath}`)
+    throw ApplicationFailure.nonRetryable(`Screenshot file not found: ${params.tempPath}`, 'FileNotFound')
   }
 
   try {
@@ -66,9 +74,13 @@ export async function processScreenshot(params: ProcessScreenshotParams): Promis
     fs.rmSync(params.tempPath, { force: true })
 
     return { snapshot }
-  } catch (err) {
-    logger.error(err)
-    throw ApplicationFailure.retryable(`Failed to process screenshot: ${err instanceof Error ? err.message : err}`)
+  } catch (error) {
+    logger.error(error)
+    throw ApplicationFailure.retryable(
+      `Failed to process screenshot: ${error instanceof Error ? error.message : error}`,
+      error instanceof Error ? error.name : 'UnknownError',
+      [{ error }],
+    )
   }
 }
 
@@ -86,14 +98,16 @@ export async function finalizeBuildSnapshots({ buildId, isSuccess }: { buildId: 
 
       await syncBuildStatusBasedOnSnapshotApprovals({ dbOrTx: tx, build })
     })
-  } catch (err) {
-    if (err instanceof ApplicationFailure) {
-      throw err
+  } catch (error) {
+    if (error instanceof ApplicationFailure) {
+      throw error
     }
 
-    logger.error(err)
+    logger.error(error)
     throw ApplicationFailure.retryable(
-      `Failed to finalize build snapshots: ${err instanceof Error ? err.message : err}`,
+      `Failed to finalize build snapshots: ${error instanceof Error ? error.message : error}`,
+      error instanceof Error ? error.name : 'UnknownError',
+      [{ error }],
     )
   }
 }
@@ -138,12 +152,16 @@ export async function notifyBuildReadyForReview({ projectId, buildId }: { projec
         },
       })
     }
-  } catch (err) {
-    if (err instanceof ApplicationFailure) {
-      throw err
+  } catch (error) {
+    if (error instanceof ApplicationFailure) {
+      throw error
     }
 
-    logger.error(err)
-    throw ApplicationFailure.retryable(`Failed to send notification: ${err instanceof Error ? err.message : err}`)
+    logger.error(error)
+    throw ApplicationFailure.retryable(
+      `Failed to send notification: ${error instanceof Error ? error.message : error}`,
+      error instanceof Error ? error.name : 'UnknownError',
+      [{ error }],
+    )
   }
 }

--- a/web/temporal/activities/project.ts
+++ b/web/temporal/activities/project.ts
@@ -32,12 +32,16 @@ export async function getSnapshotsPayload({
     const snapshotPayloads = await populateSnapshotsPayload({ project, build })
 
     return snapshotPayloads
-  } catch (err) {
-    if (err instanceof ApplicationFailure) {
-      throw err
+  } catch (error) {
+    if (error instanceof ApplicationFailure) {
+      throw error
     }
 
-    logger.error(err)
-    throw ApplicationFailure.retryable(`Failed to get snapshot payloads: ${err instanceof Error ? err.message : err}`)
+    logger.error(error)
+    throw ApplicationFailure.retryable(
+      `Failed to get snapshot payloads: ${error instanceof Error ? error.message : error}`,
+      error instanceof Error ? error.name : 'UnknownError',
+      [{ error }],
+    )
   }
 }

--- a/web/temporal/worker.ts
+++ b/web/temporal/worker.ts
@@ -1,6 +1,7 @@
 import { NativeConnection, Worker } from '@temporalio/worker'
 
 import { TEMPORAL_ADDRESS } from '@/constants/env'
+import { TEMPORAL_QUEUE_NAME } from '@/constants/temporal'
 import { logger } from '@/lib/logger'
 import * as buildActivities from '@/temporal/activities/build'
 import * as projectActivities from '@/temporal/activities/project'
@@ -15,7 +16,7 @@ async function run() {
       ...buildActivities,
       ...projectActivities,
     },
-    taskQueue: 'spotteur',
+    taskQueue: TEMPORAL_QUEUE_NAME,
   })
 
   await worker.run()

--- a/web/temporal/workflows/screenshot.ts
+++ b/web/temporal/workflows/screenshot.ts
@@ -4,7 +4,7 @@ import type * as Activities from '@/temporal/activities/build'
 import { type ScreenshotWorkflowResult, type ScreenshotWorkflowParams } from '@/types/screenshot'
 
 const { takeScreenshot, processScreenshot, markBuildAsStarted } = proxyActivities<typeof Activities>({
-  startToCloseTimeout: '15 minutes',
+  startToCloseTimeout: '30 minutes',
   retry: {
     initialInterval: '500 ms',
     maximumAttempts: 3,

--- a/web/temporal/workflows/snapshot.ts
+++ b/web/temporal/workflows/snapshot.ts
@@ -35,6 +35,11 @@ export async function buildSnapshotsWorkflow({ projectId, buildId }: GenerateSna
         return executeChild(screenshotWorkflow, {
           args: [{ payload }],
           workflowId: `build-${buildId}-snapshot-${payload.id}-${payload.browser.toString()}`,
+          retry: {
+            initialInterval: '500 ms',
+            maximumAttempts: 3,
+            backoffCoefficient: 1.5,
+          },
         })
       }),
     )

--- a/web/temporal/workflows/snapshot.ts
+++ b/web/temporal/workflows/snapshot.ts
@@ -1,6 +1,5 @@
 import { executeChild, proxyActivities } from '@temporalio/workflow'
 
-import { logger } from '../../lib/logger'
 import type * as BuildActivities from '@/temporal/activities/build'
 import type * as ProjectActivities from '@/temporal/activities/project'
 import type { GenerateSnapshotsWorkflowParams } from '@/types/screenshot'
@@ -46,7 +45,6 @@ export async function buildSnapshotsWorkflow({ projectId, buildId }: GenerateSna
 
     return `Successfully generated snapshots (${results.length} pages)`
   } catch (error) {
-    logger.error(error)
     await finalizeBuildSnapshots({ buildId, isSuccess: false })
     throw error
   }


### PR DESCRIPTION
## Fix temporal production error

## Summary

Fix error during production build related to Temporal and winston logger

## Changes

- Remove winston logger from temporal workflow, this is because temporal workflow should not modify files. See: https://docs.temporal.io/develop/typescript/observability#logging-from-workflows
- Update health check configuration to prevent unnecessary restart
- Update taskfile config to prevent orphans container
- Use node image slim version because of incompatible issue on alpine version


## Testing

N/A

## Screenshots

N/A