### PR TITLE
[SP-063] Fix viewport mismatch issue

### DIFF
--- a/web/lib/browser-engine/playwright.ts
+++ b/web/lib/browser-engine/playwright.ts
@@ -25,23 +25,15 @@ export class PlaywrightBrowserEngine implements IBrowserEngine {
 
   public async getViewportSize(): Promise<{ width: number; height: number }> {
     const viewport = this.page.viewportSize()
+    if (viewport === null) {
+      throw new Error('Unable to get viewport size')
+    }
 
-    return { width: viewport?.width || 0, height: viewport?.height || 0 }
+    return { width: viewport.width, height: viewport.height }
   }
 
-  public async setViewportSize(width: number, height: number): Promise<void> {
+  public async setViewportSize({ width, height }: { width: number; height: number }): Promise<void> {
     await this.page.setViewportSize({ width, height })
-  }
-
-  public async fitWindowToContentHeight(): Promise<void> {
-    const width = (await this.getViewportSize()).width
-
-    await this.page.setViewportSize({
-      width: width || 1280,
-      height: await this.page.evaluate(() =>
-        Math.ceil(Math.max(document.body.scrollHeight, document.documentElement.scrollHeight)),
-      ),
-    })
   }
 
   public async hideElements(selector: string): Promise<void> {

--- a/web/lib/browser-engine/playwright.ts
+++ b/web/lib/browser-engine/playwright.ts
@@ -23,8 +23,18 @@ export class PlaywrightBrowserEngine implements IBrowserEngine {
     return await this.page.evaluate<T>(new Function(`"use strict"; ${script}`) as () => T)
   }
 
+  public async getViewportSize(): Promise<{ width: number; height: number }> {
+    const viewport = this.page.viewportSize()
+
+    return { width: viewport?.width || 0, height: viewport?.height || 0 }
+  }
+
+  public async setViewportSize(width: number, height: number): Promise<void> {
+    await this.page.setViewportSize({ width, height })
+  }
+
   public async fitWindowToContentHeight(): Promise<void> {
-    const width = this.page.viewportSize()?.width
+    const width = (await this.getViewportSize()).width
 
     await this.page.setViewportSize({
       width: width || 1280,

--- a/web/lib/browser-engine/selenium.ts
+++ b/web/lib/browser-engine/selenium.ts
@@ -20,6 +20,16 @@ export class SeleniumBrowserEngine implements IBrowserEngine {
     return await this.driver.executeScript<T>(script)
   }
 
+  public async getViewportSize(): Promise<{ width: number; height: number }> {
+    const { width, height } = await this.driver.manage().window().getRect()
+
+    return { width, height }
+  }
+
+  public async setViewportSize(width: number, height: number): Promise<void> {
+    await this.driver.manage().window().setRect({ width, height })
+  }
+
   public async fitWindowToContentHeight(): Promise<void> {
     const { width } = await this.driver.manage().window().getRect()
     const fullPageHeight = await this.driver.executeScript<number>(() => {

--- a/web/lib/browser-engine/selenium.ts
+++ b/web/lib/browser-engine/selenium.ts
@@ -26,17 +26,8 @@ export class SeleniumBrowserEngine implements IBrowserEngine {
     return { width, height }
   }
 
-  public async setViewportSize(width: number, height: number): Promise<void> {
+  public async setViewportSize({ width, height }: { width: number; height: number }): Promise<void> {
     await this.driver.manage().window().setRect({ width, height })
-  }
-
-  public async fitWindowToContentHeight(): Promise<void> {
-    const { width } = await this.driver.manage().window().getRect()
-    const fullPageHeight = await this.driver.executeScript<number>(() => {
-      return Math.max(document.body.scrollHeight, document.documentElement.scrollHeight)
-    })
-
-    await this.driver.manage().window().setRect({ width: width, height: fullPageHeight })
   }
 
   public async hideElements(selector: string): Promise<void> {
@@ -193,7 +184,11 @@ export class SeleniumBrowserEngineFactory {
       .addArguments('--disable-browser-side-navigation') //https://stackoverflow.com/a/49123152/1689770
       .addArguments('--disable-gpu') //https://stackoverflow.com/questions/51959986/how-to-solve-selenium-chromedriver-timed-out-receiving-message-from-renderer-exc
     firefoxOpts.windowSize(windowSize).addArguments('--headless').addArguments('--no-sandbox')
-    edgeOpts.windowSize(windowSize).addArguments('--headless').addArguments('--no-sandbox')
+    edgeOpts
+      // Edge needs a bit more width to ensure the screenshot width is correct
+      .windowSize({ width: windowSize.width + 8, height: windowSize.height })
+      .addArguments('--headless')
+      .addArguments('--no-sandbox')
 
     const browser = payload.browser
 

--- a/web/lib/screenshot/capturer.ts
+++ b/web/lib/screenshot/capturer.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs'
 import path from 'node:path'
 
-import { STORAGE_FOLDER } from '@/constants/app'
+import { DEFAULT_SNAPSHOTS_HEIGHT, DEFAULT_SNAPSHOTS_WIDTH, STORAGE_FOLDER } from '@/constants/app'
 import { RuleAttrType } from '@/constants/enum'
 import { BROWSER_ENGINE_TYPE } from '@/constants/env'
 import { mergeGlobalVariablesIntoSnapshotPayload } from '@/features/builds/actions'
@@ -45,7 +45,8 @@ export class ScreenshotCapturer {
 
       await this.browserEngine.scrollPageToBottom()
       await this.browserEngine.scrollPageToTop()
-      await this.browserEngine.fitWindowToContentHeight()
+      // await this.browserEngine.fitWindowToContentHeight()
+      await this.fitWindowToContentHeight()
 
       await this.browserEngine.waitForNetworkIdle(30000)
       await this.browserEngine.waitForSelector(this.payload.selector, 30000)
@@ -54,6 +55,7 @@ export class ScreenshotCapturer {
 
       await this.browserEngine.scrollPageToBottom()
       await this.browserEngine.scrollPageToTop()
+      await this.fitWindowToContentHeight()
 
       logger.info(`${this.logPrefix} Capturing screenshot`)
       const buffer = await this.takeConsistentScreenshot({
@@ -136,6 +138,24 @@ export class ScreenshotCapturer {
       logger.info(`${this.logPrefix} Executing after-page-load hook`)
       await this.browserEngine?.executeScript<void>(this.payload.hooks['after-page-load'])
     }
+  }
+
+  private async fitWindowToContentHeight(): Promise<void> {
+    const viewportSize = await this.browserEngine?.getViewportSize()
+    const width = viewportSize?.width || DEFAULT_SNAPSHOTS_WIDTH
+    const height = viewportSize?.height || DEFAULT_SNAPSHOTS_HEIGHT
+    console.log(`Viewport size before fitting: ${width}x${height}`)
+
+    const fullPageHeight = await this.browserEngine?.executeScript<number>(
+      // The first part gets the full height of the page content
+      // The second part adds the difference between outerHeight and innerHeight to respect browser window size
+      'return Math.max(document.body.scrollHeight, document.documentElement.scrollHeight) + (window.outerHeight - window.innerHeight)',
+    )
+
+    const newHeight = fullPageHeight || height
+    console.log(`Viewport size after fitting: ${width}x${newHeight}`)
+
+    await this.browserEngine?.setViewportSize(width, newHeight)
   }
 
   private async runBeforeScreenshotHook(): Promise<void> {

--- a/web/lib/screenshot/capturer.ts
+++ b/web/lib/screenshot/capturer.ts
@@ -1,7 +1,9 @@
 import * as fs from 'node:fs'
 import path from 'node:path'
 
-import { DEFAULT_SNAPSHOTS_HEIGHT, DEFAULT_SNAPSHOTS_WIDTH, STORAGE_FOLDER } from '@/constants/app'
+import sharp from 'sharp'
+
+import { DEFAULT_SNAPSHOTS_HEIGHT, STORAGE_FOLDER } from '@/constants/app'
 import { RuleAttrType } from '@/constants/enum'
 import { BROWSER_ENGINE_TYPE } from '@/constants/env'
 import { mergeGlobalVariablesIntoSnapshotPayload } from '@/features/builds/actions'
@@ -30,31 +32,32 @@ export class ScreenshotCapturer {
       )
 
       logger.info(`${this.logPrefix} Navigating to page URL ${this.payload.pageUrl}`)
-      await this.browserEngine.visit(this.payload.pageUrl)
+      await this.browser().visit(this.payload.pageUrl)
 
       logger.info(`${this.logPrefix} Waiting for page to completely load`)
-      await this.browserEngine.waitForPageLoad(30000)
+      await this.browser().waitForPageLoad(30000)
 
-      const rawVariables = await this.browserEngine.executeScript<unknown>('return window.spotteur || {}')
+      const rawVariables = await this.browser().executeScript<unknown>('return window.spotteur || {}')
       this.payload = await mergeGlobalVariablesIntoSnapshotPayload({
         payload: this.payload,
         rawVariables,
       })
 
       await this.runAfterPageLoadHook()
+      await this.hideScrollbars()
 
-      await this.browserEngine.scrollPageToBottom()
-      await this.browserEngine.scrollPageToTop()
-      // await this.browserEngine.fitWindowToContentHeight()
+      await this.browser().scrollPageToBottom()
+      await this.browser().scrollPageToTop()
       await this.fitWindowToContentHeight()
 
-      await this.browserEngine.waitForNetworkIdle(30000)
-      await this.browserEngine.waitForSelector(this.payload.selector, 30000)
+      await this.browser().waitForNetworkIdle(30000)
+      await this.browser().waitForSelector(this.payload.selector, 30000)
 
       await this.runBeforeScreenshotHook()
 
-      await this.browserEngine.scrollPageToBottom()
-      await this.browserEngine.scrollPageToTop()
+      // If the hooks made any changes that causing layout shifts, this will help to stabilize it
+      await this.browser().scrollPageToBottom()
+      await this.browser().scrollPageToTop()
       await this.fitWindowToContentHeight()
 
       logger.info(`${this.logPrefix} Capturing screenshot`)
@@ -85,19 +88,26 @@ export class ScreenshotCapturer {
     consistentCount: number
   }): Promise<Buffer> {
     const screenshots: Buffer[] = []
-
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       logger.info(`${this.logPrefix} Taking screenshot attempt ${attempt}/${maxAttempts}`)
-      const buffer = await this.browserEngine?.takeScreenshot()
+      const buffer = await this.browser().takeScreenshot()
       if (!buffer) {
         throw new Error('Failed to capture screenshot')
+      }
+
+      const image = sharp(buffer).ensureAlpha().raw().toFormat('png')
+      const { info } = await image.toBuffer({ resolveWithObject: true })
+      if (info.width !== this.payload.viewportWidth) {
+        throw new Error(
+          `Screenshot width (${info.width}px) doesn't match expected viewport width (${this.payload.viewportWidth}px)`,
+        )
       }
 
       screenshots.push(buffer)
 
       // Need more screenshots before checking consistency
       if (screenshots.length < consistentCount) {
-        await this.browserEngine?.sleep(delayMs)
+        await this.browser().sleep(delayMs)
         continue
       }
 
@@ -110,7 +120,7 @@ export class ScreenshotCapturer {
       // Not consistent yet, wait before next attempt
       logger.info(`${this.logPrefix} Screenshot give different result, waiting ${delayMs}ms before retry`)
       if (attempt < maxAttempts) {
-        await this.browserEngine?.sleep(delayMs)
+        await this.browser().sleep(delayMs)
       }
     }
 
@@ -136,42 +146,73 @@ export class ScreenshotCapturer {
   private async runAfterPageLoadHook(): Promise<void> {
     if (this.payload.hooks?.['after-page-load']) {
       logger.info(`${this.logPrefix} Executing after-page-load hook`)
-      await this.browserEngine?.executeScript<void>(this.payload.hooks['after-page-load'])
+      await this.browser().executeScript<void>(this.payload.hooks['after-page-load'])
     }
   }
 
+  private async hideScrollbars(): Promise<void> {
+    await this.browser().executeScript<void>(`
+      const style = document.createElement('style')
+      style.type = 'text/css'
+      style.id = 'spotteur-hide-scrollbars-style'
+      style.appendChild(
+        document.createTextNode(\`
+          * {
+            scrollbar-width: none !important; /* Firefox */
+            -ms-overflow-style: none !important; /* Edge */
+          }
+          *::-webkit-scrollbar {
+            display: none !important; /* Chrome */
+          }
+        \`),
+      )
+      document.head.appendChild(style)
+    `)
+  }
+
   private async fitWindowToContentHeight(): Promise<void> {
-    const viewportSize = await this.browserEngine?.getViewportSize()
-    const width = viewportSize?.width || DEFAULT_SNAPSHOTS_WIDTH
-    const height = viewportSize?.height || DEFAULT_SNAPSHOTS_HEIGHT
-    console.log(`Viewport size before fitting: ${width}x${height}`)
+    const { width, height } = await this.browser().getViewportSize()
+    logger.info(`${this.logPrefix} Viewport size before fitting: ${width}x${height}`)
 
-    const fullPageHeight = await this.browserEngine?.executeScript<number>(
-      // The first part gets the full height of the page content
-      // The second part adds the difference between outerHeight and innerHeight to respect browser window size
-      'return Math.max(document.body.scrollHeight, document.documentElement.scrollHeight) + (window.outerHeight - window.innerHeight)',
-    )
+    // First set viewport height to the default to get accurate content height
+    await this.browser().setViewportSize({ width, height: DEFAULT_SNAPSHOTS_HEIGHT })
 
-    const newHeight = fullPageHeight || height
-    console.log(`Viewport size after fitting: ${width}x${newHeight}`)
+    // Find out all height values from the page to determine full content height
+    const { innerHeight, outerHeight, documentScrollHeight, bodyScrollHeight } = await this.browser().executeScript<{
+      innerHeight: number
+      outerHeight: number
+      bodyScrollHeight: number
+      documentScrollHeight: number
+    }>(`return {
+        innerHeight: window.innerHeight,
+        outerHeight: window.outerHeight,
+        bodyScrollHeight: document.body.scrollHeight,
+        documentScrollHeight: document.documentElement.scrollHeight
+    }`)
 
-    await this.browserEngine?.setViewportSize(width, newHeight)
+    // Formula:
+    // body/document scroll height for content height
+    // outerHeight - innerHeight for browser window decorations height (like address bar, etc)
+    const fullPageHeight = Math.max(bodyScrollHeight, documentScrollHeight) + (outerHeight - innerHeight)
+
+    logger.info(`${this.logPrefix} Viewport size after fitting: ${width}x${fullPageHeight}`)
+    await this.browser().setViewportSize({ width, height: fullPageHeight })
   }
 
   private async runBeforeScreenshotHook(): Promise<void> {
     if (this.payload.hooks?.['before-screenshot']) {
       logger.info(`${this.logPrefix} Executing before-screenshot hook`)
-      await this.browserEngine?.executeScript<void>(this.payload.hooks['before-screenshot'])
+      await this.browser().executeScript<void>(this.payload.hooks['before-screenshot'])
     }
 
     if (this.payload.reducedMotion) {
       logger.info(`${this.logPrefix} Enabling reduced motion`)
-      await this.browserEngine?.enableReducedMotion()
+      await this.browser().enableReducedMotion()
     }
 
     if (this.payload.mediaReset) {
       logger.info(`${this.logPrefix} Resetting time-based media`)
-      await this.browserEngine?.resetTimeBasedMedia()
+      await this.browser().resetTimeBasedMedia()
     }
 
     await this.applyRules()
@@ -183,27 +224,35 @@ export class ScreenshotCapturer {
         for (const ruleAttr of rule.attrs) {
           if (ruleAttr.name === RuleAttrType.REMOVE) {
             logger.info(`${this.logPrefix} Removing element matching selector: ${selector}`)
-            await this.browserEngine?.removeElements(selector)
+            await this.browser().removeElements(selector)
           }
 
           if (ruleAttr.name === RuleAttrType.HIDE) {
             logger.info(`${this.logPrefix} Hiding element matching selector: ${selector}`)
-            await this.browserEngine?.hideElements(selector)
+            await this.browser().hideElements(selector)
           }
 
           if (ruleAttr.name === RuleAttrType.CUSTOM) {
             logger.info(
               `${this.logPrefix} Replace innerText element with user-defined text matching selector: ${selector}`,
             )
-            await this.browserEngine?.replaceElementInnerText(selector, ruleAttr.value || '')
+            await this.browser().replaceElementInnerText(selector, ruleAttr.value || '')
           }
 
           if (ruleAttr.name === RuleAttrType.REPLACE_WORDS) {
             logger.info(`${this.logPrefix} Replace innerText element with static text matching selector: ${selector}`)
-            await this.browserEngine?.replaceElementInnerText(selector, getLoremIpsumWords(Number(ruleAttr.value)))
+            await this.browser().replaceElementInnerText(selector, getLoremIpsumWords(Number(ruleAttr.value)))
           }
         }
       }
     }
+  }
+
+  private browser(): IBrowserEngine {
+    if (!this.browserEngine) {
+      throw new Error('Browser engine not initialized yet')
+    }
+
+    return this.browserEngine
   }
 }

--- a/web/lib/screenshot/processor.ts
+++ b/web/lib/screenshot/processor.ts
@@ -119,14 +119,15 @@ export class ScreenshotProcessor {
         }
       }
 
-      if (!baselineScreenshotMediaId) {
-        logger.info(`${this.logPrefix} No baseline screenshot found`)
-      }
-
       // TODO: Maybe we can add this to project setting,
       // so user can decide wether auto-approved are allowed or not based on threshold.
       let approvalStatus = SnapshotApprovalStatus.PENDING
       if (diffPercentage === 0) {
+        approvalStatus = SnapshotApprovalStatus.APPROVED
+      }
+
+      if (!baselineScreenshotMediaId) {
+        logger.info(`${this.logPrefix} No baseline screenshot found, auto-approving snapshot`)
         approvalStatus = SnapshotApprovalStatus.APPROVED
       }
 

--- a/web/types/browser-engine.ts
+++ b/web/types/browser-engine.ts
@@ -2,11 +2,7 @@ export interface IBrowserEngine {
   enableReducedMotion(): Promise<void>
   executeScript<T>(script: string): Promise<T>
   getViewportSize(): Promise<{ width: number; height: number }>
-  setViewportSize(width: number, height: number): Promise<void>
-  /**
-   * Adjust the browser window height to fit the content height.
-   */
-  fitWindowToContentHeight(): Promise<void>
+  setViewportSize({ width, height }: { width: number; height: number }): Promise<void>
   /**
    * Hide all element matching the selector using CSS visibility property.
    */

--- a/web/types/browser-engine.ts
+++ b/web/types/browser-engine.ts
@@ -1,6 +1,8 @@
 export interface IBrowserEngine {
   enableReducedMotion(): Promise<void>
   executeScript<T>(script: string): Promise<T>
+  getViewportSize(): Promise<{ width: number; height: number }>
+  setViewportSize(width: number, height: number): Promise<void>
   /**
    * Adjust the browser window height to fit the content height.
    */


### PR DESCRIPTION
## [SP-063] Fix viewport mismatch issue

## Summary

Prevent the snapshot being inconsistent due layout shifts and auto approve snapshot if no baseline build.

## Changes

- Fix viewport issue by respecting browser window size
- Hide scrollbar using CSS to prevent it being shown in the screenshot
- Auto approve snapshot in case there is no baseline build yet

## Testing

- Checkout to this branch locally
- Build & start the project using `task start`
- Start multiple page testing as usual
- The expected result should be relatively consistent

## Screenshots

N/A
