### PR TITLE
[SP-076] Compress image and disable usage of next/image component in snapshots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ RUSTFS_INITIAL_SECRET_KEY="rustfsadmin"
 FILESYSTEM_DISK="rustfs"
 USE_EXTERNAL_SELENIUM="false"
 
-S3_ENDPOINT="http://rustfs:9000"
+S3_ENDPOINT="http://host.docker.internal:18002"
 S3_REGION="us-east-1" # When using RustFS, this can be any value
 S3_ACCESS_KEY="rustfsadmin"
 S3_SECRET_KEY="rustfsadmin"

--- a/compose.yml
+++ b/compose.yml
@@ -14,6 +14,8 @@ services:
         TEMPORAL_ADDRESS: ${TEMPORAL_ADDRESS:-}
     ports:
       - "${WEBAPP_PORT:-18000}:3000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     healthcheck:
       test: ["CMD-SHELL", "wget --spider http://0.0.0.0:3000"]
       interval: 3s
@@ -40,6 +42,8 @@ services:
         NOVU_SECRET_KEY: ${NOVU_SECRET_KEY:-}
         S3_ENDPOINT: ${S3_ENDPOINT:-}
         TEMPORAL_ADDRESS: ${TEMPORAL_ADDRESS:-}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     env_file: [".env"]
     profiles:
       - "script-runner"
@@ -50,6 +54,8 @@ services:
     build:
       context: "web"
       dockerfile: "Dockerfile.worker"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     env_file: [".env"]
     restart: "unless-stopped"
     depends_on:

--- a/web/features/snapshots/detail.tsx
+++ b/web/features/snapshots/detail.tsx
@@ -159,10 +159,16 @@ export function SnapshotViewer({
             <Comparison className="aspect-video" mode="hover">
               {/* Please note that the positions are reversed, the right position corresponds to the left side. */}
               <ComparisonItem position="right">
-                <Image src={snapshot.baselineScreenshotMedia.path} alt="Baseline" fill className="object-contain" />
+                <Image
+                  unoptimized
+                  src={snapshot.baselineScreenshotMedia.path}
+                  alt="Baseline"
+                  fill
+                  className="object-contain"
+                />
               </ComparisonItem>
               <ComparisonItem position="left">
-                <Image src={snapshot.screenshotMedia.path} alt="Current" fill className="object-contain" />
+                <Image unoptimized src={snapshot.screenshotMedia.path} alt="Current" fill className="object-contain" />
               </ComparisonItem>
               <ComparisonHandle />
               <Badge variant="outline" className="pointer-events-none absolute top-6 left-6">
@@ -180,6 +186,7 @@ export function SnapshotViewer({
           {snapshot.diffScreenshotMedia?.path ? (
             <div className="relative h-1280 w-full">
               <Image
+                unoptimized
                 src={snapshot.diffScreenshotMedia?.path}
                 alt="Diff heatmap"
                 fill
@@ -217,7 +224,7 @@ const SnapshotImage = ({ label, media }: { label?: string; media?: MediaDetailRe
         <span className="text-muted-foreground text-xs">{`${label} (${media.width}x${media.height})`}</span>
       ) : null}
       <div className="bg-muted/20 relative w-full overflow-hidden rounded-lg border" style={{ aspectRatio }}>
-        <Image src={media.path} alt={label ?? 'Snapshot preview'} fill className="object-contain" />
+        <Image unoptimized src={media.path} alt={label ?? 'Snapshot preview'} fill className="object-contain" />
       </div>
     </div>
   )

--- a/web/lib/image-diff.ts
+++ b/web/lib/image-diff.ts
@@ -61,14 +61,18 @@ export async function getImageDiff({
 
   const totalPixels = width * height
   const diffPercentage = (diffPixels / totalPixels) * 100
-  const diffPngBuffer = await sharp(diffBuffer, {
+  const diffImage = await sharp(diffBuffer, {
     raw: { width, height, channels },
   })
-    .png()
+    .png({
+      compressionLevel: 5,
+      quality: 60,
+    })
+    .toFormat('png')
     .toBuffer()
 
   return {
     diffPercentage,
-    diffImage: diffPngBuffer,
+    diffImage,
   }
 }

--- a/web/lib/screenshot/capturer.ts
+++ b/web/lib/screenshot/capturer.ts
@@ -95,7 +95,14 @@ export class ScreenshotCapturer {
         throw new Error('Failed to capture screenshot')
       }
 
-      const image = sharp(buffer).ensureAlpha().raw().toFormat('png')
+      const image = sharp(buffer)
+        .ensureAlpha()
+        .raw()
+        .png({
+          compressionLevel: 5,
+          quality: 60,
+        })
+        .toFormat('png')
       const { info } = await image.toBuffer({ resolveWithObject: true })
       if (info.width !== this.payload.viewportWidth) {
         throw new Error(

--- a/web/lib/screenshot/processor.ts
+++ b/web/lib/screenshot/processor.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs'
 
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import sharp from 'sharp'
 
 import { SnapshotApprovalStatus } from '@/constants/status-map'
@@ -45,11 +45,11 @@ export class ScreenshotProcessor {
         .onConflictDoUpdate({
           target: media.path,
           set: {
-            fileName: this.payload.fileName,
-            fileSize: buffer.length,
-            mimeType: 'image/png',
-            width: info.width,
-            height: info.height,
+            fileName: sql.raw(`excluded.${media.fileName.name}`),
+            fileSize: sql.raw(`excluded.${media.fileSize.name}`),
+            mimeType: sql.raw(`excluded.${media.mimeType.name}`),
+            width: sql.raw(`excluded.${media.width.name}`),
+            height: sql.raw(`excluded.${media.height.name}`),
           },
         })
         .returning()
@@ -100,11 +100,11 @@ export class ScreenshotProcessor {
               .onConflictDoUpdate({
                 target: media.path,
                 set: {
-                  fileName: diffFileName,
-                  fileSize: diffScreenshotBuffer.length,
-                  mimeType: 'image/png',
-                  width: info.width,
-                  height: info.height,
+                  fileName: sql.raw(`excluded.${media.fileName.name}`),
+                  fileSize: sql.raw(`excluded.${media.fileSize.name}`),
+                  mimeType: sql.raw(`excluded.${media.mimeType.name}`),
+                  width: sql.raw(`excluded.${media.width.name}`),
+                  height: sql.raw(`excluded.${media.height.name}`),
                 },
               })
               .returning()
@@ -150,11 +150,11 @@ export class ScreenshotProcessor {
         .onConflictDoUpdate({
           target: snapshots.id,
           set: {
-            approvalStatus,
-            diffPercentage,
-            screenshotMediaId: screenshotMedia.id,
-            baselineScreenshotMediaId,
-            diffScreenshotMediaId,
+            approvalStatus: sql.raw(`excluded.${snapshots.approvalStatus.name}`),
+            diffPercentage: sql.raw(`excluded.${snapshots.diffPercentage.name}`),
+            screenshotMediaId: sql.raw(`excluded.${snapshots.screenshotMediaId.name}`),
+            baselineScreenshotMediaId: sql.raw(`excluded.${snapshots.baselineScreenshotMediaId.name}`),
+            diffScreenshotMediaId: sql.raw(`excluded.${snapshots.diffScreenshotMediaId.name}`),
           },
         })
         .returning()


### PR DESCRIPTION
## [SP-076] Compress image and disable usage of next/image component in snapshots

## Summary

Compress image and disable usage of next/image component in snapshot detail page

## Changes

<!--
List the main changes introduced by this PR.
Keep it concise and high-level.
-->

- Unoptimized image on snapshot detail page
- Compress image before storing into storage
- Add extra host on `webapp` related services to allow accessing localhost in host from container

## Testing

N/A

## Screenshots

N/A
