### PR TITLE
[SP-074] Add proxy spec into the pages configuration

### DIFF
--- a/web/app/(app)/projects/[id]/pages/page.tsx
+++ b/web/app/(app)/projects/[id]/pages/page.tsx
@@ -137,7 +137,7 @@ export default function ManagePages() {
 
   const [pendingDeletePage, setPendingDeletePage] = useState<{ id: string; path: string } | null>(null)
   const deletePageMutation = useMutation({
-    mutationFn: (id: string) => deletePageRule(id),
+    mutationFn: (id: string) => deletePageRule({ projectId: params.id, id }),
     onSuccess: (res) => {
       if (res.ok) {
         queryClient.invalidateQueries({ queryKey: [QUERY_KEY_PAGE_RULES] })

--- a/web/db/migrations/0018_lucky_patch.sql
+++ b/web/db/migrations/0018_lucky_patch.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "page_rules" ADD COLUMN "proxy" text;

--- a/web/db/migrations/meta/_journal.json
+++ b/web/db/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1773124513022,
       "tag": "0017_aspiring_colonel_america",
       "breakpoints": false
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1773200000000,
+      "tag": "0018_lucky_patch",
+      "breakpoints": false
     }
   ]
 }

--- a/web/db/schema/project.ts
+++ b/web/db/schema/project.ts
@@ -113,6 +113,7 @@ export const pageRules = pgTable(
       .default(sql`'[]'::jsonb`),
     hookAfterPageLoad: text('hook_after_page_load'),
     hookBeforeScreenshot: text('hook_before_screenshot'),
+    proxy: text('proxy'),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at')
       .defaultNow()

--- a/web/features/builds/actions.ts
+++ b/web/features/builds/actions.ts
@@ -284,6 +284,7 @@ export async function populateSnapshotsPayload({
           fileName,
           reducedMotion: pageRule?.reducedMotion || false,
           mediaReset: pageRule?.mediaReset || false,
+          proxy: pageRule?.proxy ?? undefined,
           rules: pageRule?.rules,
           hooks: {
             'after-page-load': pageRule?.hookAfterPageLoad ?? undefined,

--- a/web/features/page-rules/actions.ts
+++ b/web/features/page-rules/actions.ts
@@ -103,6 +103,7 @@ export async function manageRule({ projectId, payload }: { projectId: string; pa
         rules: sql.raw(`excluded.${pageRules.rules.name}`),
         hookAfterPageLoad: sql.raw(`excluded.${pageRules.hookAfterPageLoad.name}`),
         hookBeforeScreenshot: sql.raw(`excluded.${pageRules.hookBeforeScreenshot.name}`),
+        proxy: sql.raw(`excluded.${pageRules.proxy.name}`),
       },
     })
     .returning()
@@ -110,8 +111,21 @@ export async function manageRule({ projectId, payload }: { projectId: string; pa
   return { ok: true, data: upsert }
 }
 
-export async function deletePageRule(id: string) {
-  await db.delete(pageRules).where(eq(pageRules.id, id))
+export async function deletePageRule({ projectId, id }: { projectId: string; id: string }) {
+  await db.transaction(async (tx) => {
+    await tx.delete(pageRules).where(and(eq(pageRules.id, id), eq(pageRules.projectId, projectId)))
+
+    const pageRuleRows = await tx
+      .select({ pagePath: pageRules.pagePath })
+      .from(pageRules)
+      .where(eq(pageRules.projectId, projectId))
+      .orderBy(desc(pageRules.createdAt))
+
+    await tx
+      .update(projects)
+      .set({ pagePaths: pageRuleRows.map((p) => p.pagePath) })
+      .where(eq(projects.id, projectId))
+  })
   return { ok: true }
 }
 
@@ -144,6 +158,7 @@ export async function upsertPageRules(schema: string, projectId: string) {
           rules: sql.raw(`excluded.${pageRules.rules.name}`),
           hookAfterPageLoad: sql.raw(`excluded.${pageRules.hookAfterPageLoad.name}`),
           hookBeforeScreenshot: sql.raw(`excluded.${pageRules.hookBeforeScreenshot.name}`),
+          proxy: sql.raw(`excluded.${pageRules.proxy.name}`),
         },
       })
       .returning({ id: pageRules.id })

--- a/web/features/page-rules/form.tsx
+++ b/web/features/page-rules/form.tsx
@@ -156,6 +156,7 @@ export function PageRuleForm({
   const [viewportsSectionOpen, setViewportsSectionOpen] = useState(false)
   const [rulesSectionOpen, setRulesSectionOpen] = useState(false)
   const [hooksSectionOpen, setHooksSectionOpen] = useState(false)
+  const [proxySectionOpen, setProxySectionOpen] = useState(false)
 
   const openSectionsWithInvalidFields = (fieldNames: string[]) => {
     if (hasErrorForPrefixes(fieldNames, ['viewports'])) {
@@ -168,6 +169,10 @@ export function PageRuleForm({
 
     if (hasErrorForPrefixes(fieldNames, ['hookAfterPageLoad', 'hookBeforeScreenshot'])) {
       setHooksSectionOpen(true)
+    }
+
+    if (hasErrorForPrefixes(fieldNames, ['proxy'])) {
+      setProxySectionOpen(true)
     }
   }
 
@@ -196,6 +201,7 @@ export function PageRuleForm({
   const hasServerViewportsErrors = hasErrorForPrefixes(serverFieldErrorKeys, ['viewports'])
   const hasServerRulesErrors = hasErrorForPrefixes(serverFieldErrorKeys, ['rules'])
   const hasServerHooksErrors = hasErrorForPrefixes(serverFieldErrorKeys, ['hookAfterPageLoad', 'hookBeforeScreenshot'])
+  const hasServerProxyErrors = hasErrorForPrefixes(serverFieldErrorKeys, ['proxy'])
 
   const isFormDirty = useStore(form.store, (state) => state.isDirty)
   useEffect(() => {
@@ -747,6 +753,53 @@ export function PageRuleForm({
                         value={field.state.value ?? undefined}
                         onChange={(value) => field.handleChange(value)}
                       />
+                      {isInvalid && <FieldError errors={field.state.meta.errors} />}
+                    </Field>
+                  )
+                }}
+              />
+            </CardContent>
+          </CollapsibleContent>
+        </Collapsible>
+      </Card>
+
+      <Card>
+        <Collapsible open={proxySectionOpen || hasServerProxyErrors} onOpenChange={setProxySectionOpen}>
+          <CardHeader>
+            <CardTitle>Proxy</CardTitle>
+            <CardDescription>Configure a proxy server to be used when accessing the page.</CardDescription>
+            <CardAction>
+              <CollapsibleTrigger asChild className="group">
+                <Button type="button" variant="ghost" size="icon-sm">
+                  <ChevronDown className="transition-transform group-data-[state=open]:rotate-180" />
+                  <span className="sr-only">Toggle</span>
+                </Button>
+              </CollapsibleTrigger>
+            </CardAction>
+          </CardHeader>
+          <CollapsibleContent asChild>
+            <CardContent className="pt-6">
+              <form.Field
+                name="proxy"
+                children={(field) => {
+                  const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="pageRule-proxy">Proxy server</FieldLabel>
+                      <Input
+                        id="pageRule-proxy"
+                        name={field.name}
+                        value={field.state.value ?? ''}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value || null)}
+                        placeholder="http://1.1.1.1:8080"
+                        aria-invalid={isInvalid}
+                      />
+                      <FieldDescription>
+                        Only unauthenticated HTTP proxies are supported. Accepted format{' '}
+                        <code className="font-mono">host:port</code> or{' '}
+                        <code className="font-mono">protocol://host:port</code>.
+                      </FieldDescription>
                       {isInvalid && <FieldError errors={field.state.meta.errors} />}
                     </Field>
                   )

--- a/web/features/page-rules/manage-page-content.tsx
+++ b/web/features/page-rules/manage-page-content.tsx
@@ -85,6 +85,7 @@ export function ManagePageContent({
             rules: selectedPageRule.rules,
             hookAfterPageLoad: selectedPageRule.hookAfterPageLoad,
             hookBeforeScreenshot: selectedPageRule.hookBeforeScreenshot,
+            proxy: selectedPageRule.proxy,
           }}
           onSubmit={onSubmit}
           isSubmitting={isSubmitting}

--- a/web/features/page-rules/schema.ts
+++ b/web/features/page-rules/schema.ts
@@ -161,6 +161,42 @@ export const HookAfterPageLoadSchema = z.string().nullable().optional()
 
 export const HookBeforeScreenshotSchema = z.string().nullable().optional()
 
+export const ProxySchema = z
+  .string()
+  .nullable()
+  .optional()
+  .transform((value) => value?.trim() || null)
+  .superRefine((value, ctx) => {
+    if (!value) {
+      return z.NEVER
+    }
+
+    try {
+      const proxyUrl = new URL(value.match(/^[a-zA-Z][a-zA-Z\d+.-]*:\/\//) ? value : `http://${value}`)
+      if (proxyUrl.username) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Only unauthenticated proxies are supported',
+        })
+        return z.NEVER
+      }
+
+      if (proxyUrl.protocol !== 'http:') {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Only HTTP proxies are supported',
+        })
+        return z.NEVER
+      }
+    } catch {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Invalid proxy format. Expected format is host:port or protocol://host:port',
+      })
+      return z.NEVER
+    }
+  })
+
 export const PageRuleBaseSchema = z.object({
   snapshotBrowsers: BrowsersSchema,
   viewports: ViewportsSchema,
@@ -170,6 +206,7 @@ export const PageRuleBaseSchema = z.object({
   rules: RulesSchema,
   hookAfterPageLoad: HookAfterPageLoadSchema,
   hookBeforeScreenshot: HookBeforeScreenshotSchema,
+  proxy: ProxySchema,
 })
 
 export type PageRuleFormInput = z.input<typeof PageRuleBaseSchema>

--- a/web/features/projects/actions.ts
+++ b/web/features/projects/actions.ts
@@ -72,7 +72,7 @@ export async function createProject(input: unknown) {
   const token = 'sptpt_' + crypto.randomUUID().replaceAll('-', '')
 
   const project = await db.transaction(async (tx) => {
-    const [project] = await db
+    const [project] = await tx
       .insert(projects)
       .values({
         ...parsed.data,

--- a/web/lib/browser-engine/browserless.ts
+++ b/web/lib/browser-engine/browserless.ts
@@ -3,7 +3,7 @@ import { chromium, firefox } from 'playwright-core'
 import { Browser } from '@/constants/enum'
 import { BROWSERLESS_TOKEN, BROWSERLESS_WS_ENDPOINT } from '@/constants/env'
 import { UnsupportedBrowserTypeError } from '@/lib/browser-engine'
-import { PlaywrightBrowserEngine } from '@/lib/browser-engine/playwright'
+import { PlaywrightBrowserEngine, PlaywrightBrowserEngineFactory } from '@/lib/browser-engine/playwright'
 import { type SnapshotPayload } from '@/types/screenshot'
 
 export class BrowserlessBrowserEngine extends PlaywrightBrowserEngine {}
@@ -20,12 +20,7 @@ export class BrowserlessBrowserEngineFactory {
       throw new UnsupportedBrowserTypeError(browserType)
     }
 
-    const browserContext = await browser.newContext({
-      viewport: {
-        width: payload.viewportWidth,
-        height: payload.viewportHeight,
-      },
-    })
+    const browserContext = await PlaywrightBrowserEngineFactory.createBrowserContext(browser, payload)
     const page = await browserContext.newPage()
 
     return new BrowserlessBrowserEngine(browser, page)

--- a/web/lib/browser-engine/playwright.ts
+++ b/web/lib/browser-engine/playwright.ts
@@ -147,14 +147,23 @@ export class PlaywrightBrowserEngineFactory {
       throw new UnsupportedBrowserTypeError(browserType)
     }
 
-    const browserContext = await browser.newContext({
+    const browserContext = await PlaywrightBrowserEngineFactory.createBrowserContext(browser, payload)
+    const page = await browserContext.newPage()
+
+    return new PlaywrightBrowserEngine(browser, page)
+  }
+
+  static async createBrowserContext(browser: PlaywrightBrowser, payload: SnapshotPayload) {
+    return await browser.newContext({
       viewport: {
         width: payload.viewportWidth,
         height: payload.viewportHeight,
       },
+      proxy: payload.proxy
+        ? {
+            server: payload.proxy,
+          }
+        : undefined,
     })
-    const page = await browserContext.newPage()
-
-    return new PlaywrightBrowserEngine(browser, page)
   }
 }

--- a/web/lib/browser-engine/selenium.ts
+++ b/web/lib/browser-engine/selenium.ts
@@ -1,4 +1,4 @@
-import { Builder, By, until, Browser as SeleniumBrowser } from 'selenium-webdriver'
+import { Builder, By, until, Browser as SeleniumBrowser, type ProxyConfig } from 'selenium-webdriver'
 import chrome from 'selenium-webdriver/chrome'
 import edge from 'selenium-webdriver/edge'
 import firefox from 'selenium-webdriver/firefox'
@@ -183,6 +183,7 @@ export class SeleniumBrowserEngineFactory {
       .addArguments('--disable-dev-shm-usage') //https://stackoverflow.com/a/50725918/1689770
       .addArguments('--disable-browser-side-navigation') //https://stackoverflow.com/a/49123152/1689770
       .addArguments('--disable-gpu') //https://stackoverflow.com/questions/51959986/how-to-solve-selenium-chromedriver-timed-out-receiving-message-from-renderer-exc
+
     firefoxOpts.windowSize(windowSize).addArguments('--headless').addArguments('--no-sandbox')
     edgeOpts
       // Edge needs a bit more width to ensure the screenshot width is correct
@@ -193,6 +194,19 @@ export class SeleniumBrowserEngineFactory {
     const browser = payload.browser
 
     const builder = new Builder().usingServer(SELENIUM_REMOTE_URL)
+
+    if (payload.proxy) {
+      const proxyUrl = new URL(payload.proxy)
+      const hostWithPort = `${proxyUrl.hostname}${proxyUrl.port ? `:${proxyUrl.port}` : ''}`
+      const proxyConfig: ProxyConfig = {
+        proxyType: 'manual',
+        httpProxy: hostWithPort,
+        sslProxy: hostWithPort,
+        ftpProxy: hostWithPort,
+      }
+
+      builder.setProxy(proxyConfig)
+    }
 
     let driver
     if (browser.toString() === Browser.CHROME) {

--- a/web/types/screenshot.ts
+++ b/web/types/screenshot.ts
@@ -14,6 +14,7 @@ export type SnapshotPayload = Pick<
   fileName: string
   reducedMotion: boolean
   mediaReset: boolean
+  proxy?: string
   rules?: NonNullable<z.infer<typeof SpotteurGlobalVariablesSchema>['options']>['rules']
   hooks?: z.infer<typeof SpotteurGlobalVariablesSchema>['hooks']
   globalHooks?: z.infer<typeof SpotteurGlobalVariablesSchema>['hooks']


### PR DESCRIPTION
## [SP-074] Add proxy spec into the pages configuration

## Summary

Added new page configuration to allow browser use configured proxy during testing.

## Changes

- Implement new page configuration to specify proxy server
- Improved the page rule deletion logic to use a transaction, ensuring that when a page rule is deleted, the project's `pagePaths` are updated atomically.
- Fix to use transaction object during project creation to ensure consistency.

## Testing

- Checkout to this branch locally
- Run `task up` to start all services
- Create new project and configure the base url to https://ipv4.icanhazip.com
- Run new build and wait until the build status become Test Passed
- Update page configuration to use a proxy server, you may find free proxy from https://github.com/proxifly/free-proxy-list/blob/main/proxies/protocols/http/data.txt
- Trigger new build
- Expect the new build are giving different snapshot.

## Screenshots

<img width="1490" height="1002" alt="image" src="https://github.com/user-attachments/assets/b4cc6e1e-a650-43ee-9cd8-6bab17565487" />
