### PR TITLE
[SP-084] Adjust item per page on listing page

### DIFF
--- a/web/app/(app)/projects/page.tsx
+++ b/web/app/(app)/projects/page.tsx
@@ -24,7 +24,7 @@ import { type NavigationType } from '@/types/app'
 
 export default function ProjectsPage() {
   const queryClient = useQueryClient()
-  const { page, pageSize, pagination, resetPagination, onPaginationChange } = usePagination({})
+  const { page, pageSize, pagination, resetPagination, onPaginationChange } = usePagination({ defaultPageSize: 10 })
   const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null)
 
   const columns = useMemo(
@@ -105,7 +105,7 @@ export default function ProjectsPage() {
         </div>
         <Button size="sm" asChild>
           <Link href="/projects/create">
-            <Plus className="mr-2 size-4" />
+            <Plus />
             Create Project
           </Link>
         </Button>
@@ -120,6 +120,7 @@ export default function ProjectsPage() {
           columns={columns}
           data={data?.data ?? []}
           rowCount={data?.total ?? 0}
+          pageSizeOptions={[10, 25, 50]}
         />
       )}
 

--- a/web/components/ui/data-table.tsx
+++ b/web/components/ui/data-table.tsx
@@ -19,6 +19,7 @@ interface DataTableProps<TData, TValue> {
   pagination: PaginationState
   rowCount: number
   onPaginationChange: OnChangeFn<PaginationState>
+  pageSizeOptions?: number[]
 }
 
 export function DataTable<TData, TValue>({
@@ -27,6 +28,7 @@ export function DataTable<TData, TValue>({
   pagination,
   rowCount,
   onPaginationChange,
+  pageSizeOptions,
 }: DataTableProps<TData, TValue>) {
   const table = useReactTable({
     data,
@@ -77,7 +79,7 @@ export function DataTable<TData, TValue>({
           </TableBody>
         </Table>
       </div>
-      <DataTablePagination table={table} />
+      <DataTablePagination table={table} pageSizeOptions={pageSizeOptions} />
     </div>
   )
 }

--- a/web/features/builds/list.tsx
+++ b/web/features/builds/list.tsx
@@ -13,7 +13,6 @@ import { Card, CardAction, CardContent, CardHeader, CardTitle } from '@/componen
 import { DataTablePagination } from '@/components/ui/data-table-pagination'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
 import { Skeleton } from '@/components/ui/skeleton'
-import { PAGE_SIZE_OPTIONS } from '@/constants/app'
 import { QUERY_KEY_BUILDS } from '@/constants/query-keys'
 import { type builds } from '@/db/schema'
 import { listBuildsByProject } from '@/features/builds/actions'
@@ -26,7 +25,7 @@ import { TriggerBuildDialog } from './trigger-build-dialog'
 
 export function BuildListCard({ projectId, baseUrl }: { projectId?: string; baseUrl?: string }) {
   const { page, pageSize, pagination, resetPagination, onPaginationChange } = usePagination({
-    defaultPageSize: 6,
+    defaultPageSize: 15,
   })
   const [pendingSearch, setPendingSearch] = useQueryState('search', parseAsString.withDefault(''))
   const search = useDebounce(pendingSearch, 300)
@@ -111,7 +110,7 @@ export function BuildListCard({ projectId, baseUrl }: { projectId?: string; base
                 )
               })}
             </div>
-            <DataTablePagination table={table} pageSizeOptions={PAGE_SIZE_OPTIONS} />
+            <DataTablePagination table={table} pageSizeOptions={[15, 30, 60]} />
           </>
         )}
       </CardContent>

--- a/web/features/projects/columns.tsx
+++ b/web/features/projects/columns.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { type ColumnDef } from '@tanstack/react-table'
-import { Eye, MoreHorizontal } from 'lucide-react'
+import { Eye, MoreHorizontal, Trash } from 'lucide-react'
 import Link from 'next/link'
 
 import { Button } from '@/components/ui/button'
@@ -51,7 +51,8 @@ export function getColumns(
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => onRequestDelete({ id, name })} variant="destructive">
+                <DropdownMenuItem variant="destructive" onClick={() => onRequestDelete({ id, name })}>
+                  <Trash />
                   Delete
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/web/features/snapshots/list.tsx
+++ b/web/features/snapshots/list.tsx
@@ -16,7 +16,6 @@ import { DataTablePagination } from '@/components/ui/data-table-pagination'
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from '@/components/ui/input-group'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Skeleton } from '@/components/ui/skeleton'
-import { PAGE_SIZE_OPTIONS } from '@/constants/app'
 import { BROWSER_LABEL_MAP } from '@/constants/enum'
 import { QUERY_KEY_SNAPSHOTS } from '@/constants/query-keys'
 import { BuildStatus, SNAPSHOT_APPROVAL_STATUS_OPTIONS } from '@/constants/status-map'
@@ -29,7 +28,7 @@ import { cn } from '@/lib/utils'
 
 export function SnapshotListCard({ build }: { build?: typeof builds.$inferSelect | null }) {
   const { page, pageSize, pagination, resetPagination, onPaginationChange } = usePagination({
-    defaultPageSize: 6,
+    defaultPageSize: 12,
   })
   const [isApprovalStatusFilterOpen, setIsApprovalStatusFilterOpen] = useState(false)
   const [pendingSearch, setPendingSearch] = useQueryState('search', parseAsString.withDefault(''))
@@ -175,7 +174,7 @@ export function SnapshotListCard({ build }: { build?: typeof builds.$inferSelect
             </div>
           )}
         </div>
-        <DataTablePagination table={table} pageSizeOptions={PAGE_SIZE_OPTIONS} />
+        <DataTablePagination table={table} pageSizeOptions={[12, 24, 48]} />
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
## [SP-084] Adjust item per page on listing page

## Summary

Adjust item per page on listing page

## Changes

- Adjust item per page on listing page
- Made the "Create Project" button more visually consistent by removing the margin from the plus icon.
- Improved the delete action in the projects table by adding a trash icon.

## Testing

- Checkout to this branch locally
- Run `task up` to start all services
- Verify all changes on all listing pages

## Screenshots

N/A
