### PR TITLE
[SP-086] Remove snapshots from breadcrumbs navigation

### DIFF
--- a/web/app/(app)/projects/[id]/builds/[buildId]/snapshots/[snapshotId]/page.tsx
+++ b/web/app/(app)/projects/[id]/builds/[buildId]/snapshots/[snapshotId]/page.tsx
@@ -65,12 +65,6 @@ export default function SnapshotDetailPage() {
           </BreadcrumbItem>
           <BreadcrumbSeparator />
           <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link href={`/projects/${params.id}/builds/${params.buildId}/snapshots`}>Snapshots</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
             <BreadcrumbPage>Page path {snapshotData.snapshot.pagePath}</BreadcrumbPage>
           </BreadcrumbItem>
         </>

--- a/web/app/(app)/projects/[id]/builds/[buildId]/snapshots/page.tsx
+++ b/web/app/(app)/projects/[id]/builds/[buildId]/snapshots/page.tsx
@@ -88,22 +88,14 @@ export default function BuildDetailSnapshotsPage() {
           </BreadcrumbItem>
           <BreadcrumbSeparator />
           <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link href={`/projects/${params.id}/builds/${params.buildId}/snapshots` as Route}>
-                {buildData.identifier}
-              </Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage>Snapshots</BreadcrumbPage>
+            <BreadcrumbPage>{buildData.identifier}</BreadcrumbPage>
           </BreadcrumbItem>
         </>
       ) : null,
     [projectData, buildData, params],
   )
-
   useHeaderBreadcrumbs(breadcrumbs, isLoading)
+
   const navigations = useMemo<NavigationType[]>(
     () => snapshotsMenu(params.id, params.buildId),
     [params.id, params.buildId],

--- a/web/app/(app)/projects/[id]/builds/[buildId]/snapshots/review/page.tsx
+++ b/web/app/(app)/projects/[id]/builds/[buildId]/snapshots/review/page.tsx
@@ -151,12 +151,6 @@ export default function SnapshotReviewPage() {
           </BreadcrumbItem>
           <BreadcrumbSeparator />
           <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link href={`/projects/${params.id}/builds/${params.buildId}/snapshots`}>Snapshots</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
             <BreadcrumbPage>Review Changes</BreadcrumbPage>
           </BreadcrumbItem>
         </>


### PR DESCRIPTION
## [SP-086] Remove snapshots from breadcrumbs navigation

## Summary

This pull request simplifies the breadcrumb navigation across several snapshot-related pages in the project. The main change is the removal of the intermediate "Snapshots" breadcrumb item, making the navigation more concise and focused on the current context.

## Changes

- Removed the "Snapshots" breadcrumb item from the following pages:
  - /projects/[id]/builds/[buildId]/snapshots
  - /projects/[id]/builds/[buildId]/snapshots/review
  - /projects/[id]/builds/[buildId]/snapshots/[snapshotId]

## Testing

- Checkout to this branch locally
- Run `task up` to start all services
- Verify changes on the affected pages

## Screenshots

- /projects/[id]/builds/[buildId]/snapshots

  <img width="798" height="56" alt="image" src="https://github.com/user-attachments/assets/e13fad6f-7057-4afe-9680-4d8ead6ac655" />

- /projects/[id]/builds/[buildId]/snapshots/review

  <img width="931" height="57" alt="image" src="https://github.com/user-attachments/assets/7b079cdf-84ef-4417-82c8-67c7d20ded4c" />

- /projects/[id]/builds/[buildId]/snapshots/[snapshotId]

  <img width="919" height="59" alt="image" src="https://github.com/user-attachments/assets/d530b6b7-ed1f-4d29-8c8c-2a0a8282d519" />
