### PR TITLE
fix: Update volume permissions for temporal storage

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.7",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4",
+      "integrity": "sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f",
+      "integrity": "sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,7 +53,8 @@
   // "forwardPorts": []
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": {
-    "install-deps": "cd web/ && npm install"
+    "install-deps": "cd web/ && npm install",
+    "chown:temporal-dir": "sudo chown vscode:vscode -R \"${TEMPORAL_DEFAULT_STORAGE_DIR:-/storage}\""
   }
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,9 +31,10 @@
       "installDirectlyFromGitHubRelease": true,
       "version": "latest"
     },
-    "ghcr.io/devcontainers/features/node:1": {
+    "ghcr.io/devcontainers/features/node:2": {
       "nodeGypDependencies": true,
       "version": "lts",
+      "npmVersion": "latest",
       "pnpmVersion": "latest",
       "nvmVersion": "latest"
     }

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -34,3 +34,14 @@ services:
     volumes:
       - "webapp-worker_storage:/storage"
       - "./web/logs:/app/logs"
+  volume-permission-helper:
+    image: "alpine"
+    volumes:
+      - "webapp-worker_storage:/storage"
+    command: >
+      sh -c "
+        chown -R 1001:1001 /storage &&
+        echo 'Volume permissions fixed' &&
+        exit 0
+      "
+    restart: "on-failure"

--- a/compose.yml
+++ b/compose.yml
@@ -61,17 +61,6 @@ services:
     depends_on:
       temporal:
         condition: "service_healthy"
-  volume-permission-helper:
-    image: "alpine"
-    volumes:
-      - "webapp-worker_storage:/storage"
-    command: >
-      sh -c "
-        chown -R 1001:1001 /storage &&
-        echo 'Volume permissions fixed' &&
-        exit 0
-      "
-    restart: "on-failure"
 
 volumes:
   postgres-temporal_data:


### PR DESCRIPTION
## fix: Update volume permissions for temporal storage

## Summary

Update volume permissions for temporal storage & update Node.js devcontainer feature.

## Changes

- Move `volume-permission-helper` service from `compose.yml` to `compose.prod.yml` since for development will be handled using`postCreateCommand`.
- Added a `postCreateCommand` to change ownership of Temporal storage directory.
- Upgraded the Node.js devcontainer feature from version 1 to version 2 and set `npmVersion` to `latest` for improved tooling support.

## Testing

N/A

## Screenshots

N/A
