### PR TITLE
[SP-089] Implement build table layout

### DIFF
--- a/web/app/(app)/projects/[id]/builds/page.tsx
+++ b/web/app/(app)/projects/[id]/builds/page.tsx
@@ -55,8 +55,8 @@ export default function ProjectBuildsPage() {
   }
 
   return (
-    <div className="space-y-4 p-4">
-      <BuildListCard projectId={data?.id} baseUrl={data?.baseUrl} />
+    <div className="space-y-4">
+      <BuildListCard projectId={data?.id} projectBaseUrl={data?.baseUrl} />
     </div>
   )
 }

--- a/web/features/builds/columns.tsx
+++ b/web/features/builds/columns.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { type ColumnDef } from '@tanstack/react-table'
+import { Logs, Wallpaper } from 'lucide-react'
+import Link from 'next/link'
+
+import { Button } from '@/components/ui/button'
+import { type builds } from '@/db/schema'
+import { formatDateTime } from '@/lib/utils'
+
+import { BuildStatusBadge } from './badge'
+
+export function getColumns(): ColumnDef<typeof builds.$inferSelect>[] {
+  return [
+    {
+      id: 'identifier',
+      accessorKey: 'identifier',
+      header: 'Identifier',
+    },
+    {
+      id: 'baseUrl',
+      accessorKey: 'baseUrl',
+      header: 'Base URL',
+    },
+    {
+      id: 'status',
+      accessorKey: 'status',
+      header: 'Status',
+      cell: ({ row }) => <BuildStatusBadge status={row.original.status} />,
+    },
+    {
+      id: 'createdAt',
+      accessorKey: 'createdAt',
+      header: 'Created At',
+      cell: ({ row }) => formatDateTime(row.original.createdAt),
+    },
+    {
+      id: 'action',
+      header: '',
+      cell: ({ row }) => {
+        return (
+          <div className="flex items-center justify-end gap-2">
+            <Button variant="ghost" size="sm" asChild>
+              <Link href={`/builds/${row.original.id}/snapshots`}>
+                <Wallpaper />
+                Snapshots
+              </Link>
+            </Button>
+            <Button variant="ghost" size="sm" asChild>
+              <Link href={`/builds/${row.original.id}/logs`}>
+                <Logs />
+                Logs
+              </Link>
+            </Button>
+          </div>
+        )
+      },
+    },
+  ]
+}

--- a/web/features/builds/list.tsx
+++ b/web/features/builds/list.tsx
@@ -1,29 +1,28 @@
 'use client'
 
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
-import { getCoreRowModel, getPaginationRowModel, useReactTable } from '@tanstack/react-table'
-import { Layers, Play, Search, X } from 'lucide-react'
-import { type Route } from 'next'
-import Link from 'next/link'
+import { Play, Search, X } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 import { parseAsString, useQueryState } from 'nuqs'
 import { useCallback } from 'react'
 
+import { TableSkeleton } from '@/components/table-skeleton'
 import { Button } from '@/components/ui/button'
-import { Card, CardAction, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { DataTablePagination } from '@/components/ui/data-table-pagination'
+import { DataTable } from '@/components/ui/data-table'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
 import { Skeleton } from '@/components/ui/skeleton'
 import { QUERY_KEY_BUILDS } from '@/constants/query-keys'
-import { type builds } from '@/db/schema'
 import { listBuildsByProject } from '@/features/builds/actions'
-import { BuildStatusBadge } from '@/features/builds/badge'
 import { useDebounce } from '@/hooks/use-debounce'
 import { usePagination } from '@/hooks/use-pagination'
-import { formatDateTime } from '@/lib/utils'
 
+import { getColumns } from './columns'
 import { TriggerBuildDialog } from './trigger-build-dialog'
 
-export function BuildListCard({ projectId, baseUrl }: { projectId?: string; baseUrl?: string }) {
+const columns = getColumns()
+
+export function BuildListCard({ projectId, projectBaseUrl }: { projectId?: string; projectBaseUrl?: string }) {
+  const router = useRouter()
   const { page, pageSize, pagination, resetPagination, onPaginationChange } = usePagination({
     defaultPageSize: 15,
   })
@@ -35,20 +34,6 @@ export function BuildListCard({ projectId, baseUrl }: { projectId?: string; base
     queryFn: () => listBuildsByProject({ projectId: projectId || '', page, pageSize, search }),
     enabled: !!projectId,
     placeholderData: keepPreviousData,
-  })
-
-  // eslint-disable-next-line react-hooks/incompatible-library
-  const table = useReactTable({
-    data: data?.data ?? [],
-    columns: [],
-    rowCount: data?.total ?? 0,
-    manualPagination: true,
-    state: {
-      pagination,
-    },
-    getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    onPaginationChange,
   })
 
   const handleSearchChange = useCallback(
@@ -65,9 +50,9 @@ export function BuildListCard({ projectId, baseUrl }: { projectId?: string; base
   }, [setPendingSearch, resetPagination])
 
   return (
-    <Card>
-      <CardHeader className="gap-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+    <>
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-1 items-center gap-2">
           <InputGroup className="max-w-sm flex-1">
             <InputGroupInput
               placeholder="Search builds by identifier..."
@@ -84,77 +69,31 @@ export function BuildListCard({ projectId, baseUrl }: { projectId?: string; base
             )}
           </InputGroup>
         </div>
-        <CardAction className="flex flex-row items-center justify-end gap-2 pb-0">
-          {projectId && baseUrl ? (
-            <TriggerBuildDialog projectId={projectId} baseUrl={baseUrl}>
-              <Button size="sm">
-                <Play /> Trigger build
-              </Button>
-            </TriggerBuildDialog>
-          ) : (
-            <Skeleton className="h-8 w-32" />
-          )}
-        </CardAction>
-      </CardHeader>
-      <CardContent>
-        {!projectId || isLoading ? (
-          <BuildListSkeleton />
+
+        {projectId && projectBaseUrl ? (
+          <TriggerBuildDialog projectId={projectId} baseUrl={projectBaseUrl}>
+            <Button size="sm">
+              <Play /> Trigger Build
+            </Button>
+          </TriggerBuildDialog>
         ) : (
-          <>
-            <div className="grid gap-4 pb-6 md:grid-cols-2 xl:grid-cols-3">
-              {data?.data?.map((build) => {
-                return (
-                  <Link key={build.id} href={`/builds/${build.id}/snapshots` as Route}>
-                    <BuildItemCard build={build} />
-                  </Link>
-                )
-              })}
-            </div>
-            <DataTablePagination table={table} pageSizeOptions={[15, 30, 60]} />
-          </>
+          <Skeleton className="h-8 w-32" />
         )}
-      </CardContent>
-    </Card>
-  )
-}
+      </div>
 
-function BuildItemCard({ build }: { build: typeof builds.$inferSelect }) {
-  return (
-    <Card className="hover:border-primary h-full transition">
-      <CardHeader className="flex items-start justify-between gap-3">
-        <CardTitle className="line-clamp-2 text-lg">{build.identifier}</CardTitle>
-        <BuildStatusBadge status={build.status} />
-      </CardHeader>
-      <CardContent className="text-muted-foreground space-y-3 text-sm">
-        <div className="flex items-center gap-2">
-          <Layers className="size-4" />
-          <span>{build.pagePaths?.length ?? 0} pages</span>
-        </div>
-        <div className="flex flex-wrap items-center gap-3 text-xs">
-          <span className="text-foreground">Created {formatDateTime(build.createdAt)}</span>
-        </div>
-      </CardContent>
-    </Card>
-  )
-}
-
-function BuildListSkeleton() {
-  return (
-    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-      {Array.from({ length: 6 }).map((_, idx) => (
-        <Card key={idx} className="h-full">
-          <CardHeader className="space-y-2">
-            <div className="flex items-start justify-between gap-2">
-              <Skeleton className="h-16 w-5/8" />
-              <Skeleton className="h-6 w-2/8" />
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <Skeleton className="h-3 w-24" />
-            <Skeleton className="h-4 w-32" />
-          </CardContent>
-        </Card>
-      ))}
-    </div>
+      {!projectId || isLoading ? (
+        <TableSkeleton rows={5} columns={5} />
+      ) : (
+        <DataTable
+          pagination={pagination}
+          onPaginationChange={onPaginationChange}
+          columns={columns}
+          data={data?.data ?? []}
+          rowCount={data?.total ?? 0}
+          onRowClick={(row) => router.push(`/builds/${row.id}/snapshots`)}
+          pageSizeOptions={[15, 30, 60]}
+        />
+      )}
+    </>
   )
 }

--- a/web/features/projects/columns.tsx
+++ b/web/features/projects/columns.tsx
@@ -70,7 +70,13 @@ export function getColumns(
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem variant="destructive" onClick={() => onRequestDelete({ id, name })}>
+                <DropdownMenuItem
+                  variant="destructive"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onRequestDelete({ id, name })
+                  }}
+                >
                   <Trash />
                   Delete
                 </DropdownMenuItem>

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev\" \"email dev --port=3001 --dir=./emails\" \"novu dev --port 3000 --studio-host 0.0.0.0 --studio-port 3002 --headless\"",
+    "dev": "next dev",
+    "email:dev": "email dev --port=3001 --dir=./emails",
+    "novu:dev": "novu dev --port 3000 --studio-host 0.0.0.0 --studio-port 3002 --headless",
     "build": "NODE_ENV=production next build",
     "start": "next start",
     "worker:dev": "tsx watch ./temporal/worker.ts",


### PR DESCRIPTION
## [SP-089] Implement build table layout

## Summary

Implement build table layout and some improvement.

## Changes

- Replaces the card/grid-based builds list with a paginated table
- Simplifies the `dev` script in `package.json` to only start Next.js by default, and move React Email and Novu Framework to separate command for smoother development experience.
- Fixes the delete project menu item to prevent click event propagation

## Testing

- Checkout to this branch locally
- Run `task up` to start all services
- Open any build listing page and verify that its using table instead of card

## Screenshots

N/A