### PR TITLE
[SP-115] Automatically refresh after updating approval status

### DIFF
--- a/web/features/snapshots/detail.tsx
+++ b/web/features/snapshots/detail.tsx
@@ -47,7 +47,7 @@ export function SnapshotActionButtons({
           queryKey: [QUERY_KEY_SNAPSHOTS, projectId, buildId, snapshotId],
         })
         queryClient.invalidateQueries({
-          queryKey: [QUERY_KEY_SNAPSHOTS, projectId, buildId, 'review-tree'],
+          queryKey: [QUERY_KEY_SNAPSHOTS, buildId, 'review-tree'],
         })
 
         const statusMessages = {


### PR DESCRIPTION
## [SP-115] Automatically refresh after updating approval status

## Summary

Fix after triggering approval status, the UI status should be auto-updated

## Changes

- Remove unused query key from the invalidate function

## Testing

- go to snapshots review tree
- click the approval button
- The result should be that, after clicking the button, the UI status should be auto-updated

