### PR TITLE
[SP-114] Add Filter by approval status on snapshot page

### DIFF
--- a/web/app/(app)/builds/[buildId]/snapshots/page.tsx
+++ b/web/app/(app)/builds/[buildId]/snapshots/page.tsx
@@ -129,7 +129,7 @@ export default function BuildDetailSnapshotPage() {
     if (!selectedPath && snapshotItems.length > 0) {
       setSelectedPath(snapshotItems[0].pagePath)
     }
-  }, [selectedPath, snapshotItems, setSelectedPath, status])
+  }, [selectedPath, snapshotItems, setSelectedPath])
 
   useEffect(() => {
     if (!selectedSnapshotId) {
@@ -245,10 +245,7 @@ export default function BuildDetailSnapshotPage() {
             <SnapshotReviewTree
               snapshotItems={snapshotItems}
               selectedPath={selectedPath}
-              onSelectNode={(node) => {
-                console.log('test ', node)
-                return setSelectedPath(node.path)
-              }}
+              onSelectNode={(node) => setSelectedPath(node.path)}
               filterApplied={searchQuery.length > 0 || browsers.length > 0 || hideExactlyMatch || hideNewPage}
             />
           </ResizablePanel>

--- a/web/app/(app)/builds/[buildId]/snapshots/page.tsx
+++ b/web/app/(app)/builds/[buildId]/snapshots/page.tsx
@@ -27,6 +27,7 @@ export default function BuildDetailSnapshotPage() {
   const [selectedPath, setSelectedPath] = useQueryState('path', parseAsString.withDefault(''))
   const [searchQuery, setSearchQuery] = useQueryState('search', parseAsString.withDefault(''))
   const [browsers, setBrowsers] = useQueryState('browsers', parseAsArrayOf(parseAsString).withDefault([]))
+  const [status, setStatus] = useQueryState('status', parseAsString.withDefault(''))
   const [hideExactlyMatch, setHideExactlyMatch] = useQueryState('hideExactlyMatch', parseAsBoolean.withDefault(false))
   const [hideNewPage, setHideNewPage] = useQueryState('hideNewPage', parseAsBoolean.withDefault(false))
 
@@ -72,12 +73,19 @@ export default function BuildDetailSnapshotPage() {
     return (snapshotsData?.data ?? []).filter((snapshot) => {
       const matchesSearch = snapshot.pagePath.toLowerCase().includes(searchQuery.toLowerCase())
       const matchesBrowserFilter = browsers.length === 0 || browsers.includes(snapshot.browser)
+      const matchesStatusFilter = !status || snapshot.approvalStatus === status
       const matchesExactlyMatchFilter = hideExactlyMatch ? snapshot.diffPercentage !== 0 : true
       const matchesNewPageFilter = hideNewPage ? !!snapshot.baselineScreenshotMedia : true
 
-      return matchesSearch && matchesBrowserFilter && matchesExactlyMatchFilter && matchesNewPageFilter
+      return (
+        matchesSearch &&
+        matchesBrowserFilter &&
+        matchesStatusFilter &&
+        matchesExactlyMatchFilter &&
+        matchesNewPageFilter
+      )
     })
-  }, [snapshotsData, searchQuery, browsers, hideExactlyMatch, hideNewPage])
+  }, [snapshotsData, searchQuery, browsers, hideExactlyMatch, hideNewPage, status])
 
   const processedItems = useMemo(() => {
     const processedPages = snapshotsData?.data.length ?? 0
@@ -116,10 +124,10 @@ export default function BuildDetailSnapshotPage() {
   const [openedSnapshotIds, setOpenedSnapshotIds] = useState<string[]>([])
 
   useEffect(() => {
-    if (!selectedPath && snapshotItems.length > 0) {
+    if ((!selectedPath || !status || status) && snapshotItems.length > 0) {
       setSelectedPath(snapshotItems[0].pagePath)
     }
-  }, [selectedPath, snapshotItems, setSelectedPath])
+  }, [selectedPath, snapshotItems, setSelectedPath, status])
 
   useEffect(() => {
     if (!selectedSnapshotId) {
@@ -215,6 +223,8 @@ export default function BuildDetailSnapshotPage() {
           setSearchQuery={setSearchQuery}
           browsers={browsers}
           setBrowsers={setBrowsers}
+          status={status}
+          setStatus={setStatus}
           hideExactlyMatch={hideExactlyMatch}
           setHideExactlyMatch={setHideExactlyMatch}
           hideNewPage={hideNewPage}

--- a/web/app/(app)/builds/[buildId]/snapshots/page.tsx
+++ b/web/app/(app)/builds/[buildId]/snapshots/page.tsx
@@ -123,8 +123,10 @@ export default function BuildDetailSnapshotPage() {
 
   const [openedSnapshotIds, setOpenedSnapshotIds] = useState<string[]>([])
 
+  // On first load:
+  // Set selected path to the first snapshot items
   useEffect(() => {
-    if ((!selectedPath || !status || status) && snapshotItems.length > 0) {
+    if (!selectedPath && snapshotItems.length > 0) {
       setSelectedPath(snapshotItems[0].pagePath)
     }
   }, [selectedPath, snapshotItems, setSelectedPath, status])
@@ -137,6 +139,14 @@ export default function BuildDetailSnapshotPage() {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setOpenedSnapshotIds((prev) => (prev.includes(selectedSnapshotId) ? prev : [...prev, selectedSnapshotId]))
   }, [selectedSnapshotId])
+
+  // On filter changed:
+  // Set selected path to the first snapshot items
+  useEffect(() => {
+    if (snapshotItems.length > 0) {
+      setSelectedPath(snapshotItems[0].pagePath)
+    }
+  }, [snapshotItems, status, browsers, hideExactlyMatch, hideNewPage, setSelectedPath])
 
   const onChangeOpenedSnapshot = (snapshotId: string, open: boolean) => {
     setOpenedSnapshotIds((prev) => {
@@ -235,7 +245,10 @@ export default function BuildDetailSnapshotPage() {
             <SnapshotReviewTree
               snapshotItems={snapshotItems}
               selectedPath={selectedPath}
-              onSelectNode={(node) => setSelectedPath(node.path)}
+              onSelectNode={(node) => {
+                console.log('test ', node)
+                return setSelectedPath(node.path)
+              }}
               filterApplied={searchQuery.length > 0 || browsers.length > 0 || hideExactlyMatch || hideNewPage}
             />
           </ResizablePanel>

--- a/web/features/snapshots/review-filters.tsx
+++ b/web/features/snapshots/review-filters.tsx
@@ -14,12 +14,15 @@ import {
 import { Field, FieldLabel } from '@/components/ui/field'
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from '@/components/ui/input-group'
 import { BROWSER_OPTIONS } from '@/constants/enum'
+import { SNAPSHOT_APPROVAL_STATUS_OPTIONS } from '@/constants/status-map'
 
 interface SnapshotReviewFiltersProps {
   searchQuery: string
   setSearchQuery: (value: string) => void
   browsers: string[]
   setBrowsers: (updater: (prev: string[]) => string[]) => void
+  status: string
+  setStatus: (value: string) => void
   hideExactlyMatch: boolean
   setHideExactlyMatch: (value: boolean) => void
   hideNewPage: boolean
@@ -31,6 +34,8 @@ export function SnapshotReviewFilters({
   setSearchQuery,
   browsers,
   setBrowsers,
+  status,
+  setStatus,
   hideExactlyMatch,
   setHideExactlyMatch,
   hideNewPage,
@@ -74,6 +79,33 @@ export function SnapshotReviewFilters({
                     setBrowsers((prev) => [...prev, value])
                   } else {
                     setBrowsers((prev) => prev.filter((b) => b !== value.toString()))
+                  }
+                }}
+              >
+                {label}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" className="w-58 justify-start">
+            {status ? `Filtered by status: ${status}` : 'Filter by status...'}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuGroup>
+            {SNAPSHOT_APPROVAL_STATUS_OPTIONS.map(({ value, label }) => (
+              <DropdownMenuCheckboxItem
+                key={value}
+                checked={status === value}
+                onSelect={(e) => e.preventDefault()}
+                onCheckedChange={(checked) => {
+                  if (checked) {
+                    setStatus(value)
+                  } else {
+                    setStatus('')
                   }
                 }}
               >


### PR DESCRIPTION
## [SP-114] Add Filter by approval status on snapshot page

## Summary

Add a new feature to filter snapshots by approval status

## Changes

- page
- review-tree

## Testing

- Go to snapshots review tree
- Try to filter the snapshots by status
- The result should be shown by the selected status

## Screenshot
Before:
<img width="2274" height="1082" alt="image" src="https://github.com/user-attachments/assets/b81c27c4-1d45-4218-a172-14611d1caad5" />

After:
<img width="3348" height="868" alt="image" src="https://github.com/user-attachments/assets/113a72da-8410-4816-b745-78d48574d3d8" />


