### PR TITLE
[SP-113] Remove avatar and item per page field in better auth ui

### DIFF
--- a/web/app/(app)/account/settings/page.tsx
+++ b/web/app/(app)/account/settings/page.tsx
@@ -5,44 +5,25 @@ import {
   ChangePasswordCard,
   DeleteAccountCard,
   SessionsCard,
-  UpdateAvatarCard,
-  UpdateFieldCard,
   UpdateNameCard,
 } from '@daveyplate/better-auth-ui'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 
 import { useHeaderBreadcrumbs, useHeaderNavigations } from '@/components/layout/header-context'
 import { defaultMenu } from '@/constants/app'
-import { authClient } from '@/lib/auth-client'
 import { type NavigationType } from '@/types/app'
 
 export default function SettingsPage() {
-  const [itemPerPage, setItemPerPage] = useState<number>()
-
-  useEffect(() => {
-    const process = async () => {
-      const result = await authClient.getSession()
-      const data = result.data
-
-      if (data) {
-        setItemPerPage(data.user.itemPerPage)
-      }
-    }
-    process()
-  }, [])
-
   const navigations = useMemo<NavigationType[]>(() => defaultMenu(), [])
   useHeaderNavigations(navigations)
   useHeaderBreadcrumbs(null, !navigations)
 
   return (
     <div className="flex flex-col gap-6">
-      <UpdateAvatarCard />
       <UpdateNameCard />
       <ChangeEmailCard />
       <ChangePasswordCard />
       <SessionsCard />
-      <UpdateFieldCard name="itemPerPage" label="Items per page" type="number" value={itemPerPage} />
       <DeleteAccountCard />
     </div>
   )


### PR DESCRIPTION
## [SP-113] Remove avatar and item per page field in better auth ui

## Summary

Remove unused field from better auth in profile page

## Changes

- Account page

## Testing

- go to the page profile
- the  avatar field and item per page should be removed

## Screenshots

<img width="3402" height="818" alt="image" src="https://github.com/user-attachments/assets/c6943397-49f9-4326-919b-6461aeb1ab8d" />


