### PR TITLE
[SP-111] Implement bulk update status in the snapshots page

### DIFF
--- a/web/app/(app)/builds/[buildId]/snapshots/page.tsx
+++ b/web/app/(app)/builds/[buildId]/snapshots/page.tsx
@@ -18,7 +18,7 @@ import { QUERY_KEY_BUILDS, QUERY_KEY_SNAPSHOTS } from '@/constants/query-keys'
 import { BuildStatus, SnapshotApprovalStatus } from '@/constants/status-map'
 import { getBuildDetail, resumeBuild } from '@/features/builds/actions'
 import { BuildSummaryCard } from '@/features/builds/summary'
-import { listSnapshotsByBuildV2, updateSnapshotApprovalStatus } from '@/features/snapshots/actions'
+import { bulkUpdateSnapshotApprovalStatus, listSnapshotsByBuildV2 } from '@/features/snapshots/actions'
 import { SnapshotReviewContent } from '@/features/snapshots/review-content'
 import { SnapshotReviewFilters } from '@/features/snapshots/review-filters'
 import { SnapshotReviewTree } from '@/features/snapshots/review-tree'
@@ -34,7 +34,7 @@ export default function BuildDetailSnapshotPage() {
   const [hideExactlyMatch, setHideExactlyMatch] = useQueryState('hideExactlyMatch', parseAsBoolean.withDefault(false))
   const [hideNewPage, setHideNewPage] = useQueryState('hideNewPage', parseAsBoolean.withDefault(false))
   const [bulkItems, setBulkItems] = useState<string[]>([])
-  const [bulkStatus, setBulkStatus] = useState<SnapshotApprovalStatus>(SnapshotApprovalStatus.APPROVED)
+  const [bulkStatus, setBulkStatus] = useState<string>('approve')
 
   const queryClient = useQueryClient()
 
@@ -123,15 +123,15 @@ export default function BuildDetailSnapshotPage() {
 
   const { mutate: updateBulkStatus, isPending: isBulkUpdatePending } = useMutation({
     mutationFn: async (ids: string[]) => {
-      ids.map((i) =>
-        updateSnapshotApprovalStatus({
-          snapshotId: i,
-          status: bulkStatus,
-        }),
-      )
+      const bulkStatusUpdate =
+        bulkStatus === 'approve' ? SnapshotApprovalStatus.APPROVED : SnapshotApprovalStatus.REJECTED
+      return bulkUpdateSnapshotApprovalStatus({
+        snapshotIds: ids,
+        status: bulkStatusUpdate,
+      })
     },
-    onSuccess: (res, status) => {
-      if (status) {
+    onSuccess: (res) => {
+      if (res.ok) {
         queryClient.invalidateQueries({
           queryKey: [QUERY_KEY_SNAPSHOTS, params.buildId, 'review-tree'],
         })
@@ -213,7 +213,7 @@ export default function BuildDetailSnapshotPage() {
 
   const isLoading = isLoadingBuild || isLoadingSnapshots
 
-  const onBulkActionChange = (value: SnapshotApprovalStatus) => {
+  const onBulkActionChange = (value: string) => {
     if (!value) {
       return
     }

--- a/web/app/(app)/builds/[buildId]/snapshots/page.tsx
+++ b/web/app/(app)/builds/[buildId]/snapshots/page.tsx
@@ -34,7 +34,7 @@ export default function BuildDetailSnapshotPage() {
   const [hideExactlyMatch, setHideExactlyMatch] = useQueryState('hideExactlyMatch', parseAsBoolean.withDefault(false))
   const [hideNewPage, setHideNewPage] = useQueryState('hideNewPage', parseAsBoolean.withDefault(false))
   const [bulkItems, setBulkItems] = useState<string[]>([])
-  const [bulkStatus, setBulkStatus] = useState<string>('approve')
+  const [bulkStatus, setBulkStatus] = useState<SnapshotApprovalStatus>(SnapshotApprovalStatus.APPROVED)
 
   const queryClient = useQueryClient()
 
@@ -122,14 +122,11 @@ export default function BuildDetailSnapshotPage() {
   })
 
   const { mutate: updateBulkStatus, isPending: isBulkUpdatePending } = useMutation({
-    mutationFn: async (ids: string[]) => {
-      const bulkStatusUpdate =
-        bulkStatus === 'approve' ? SnapshotApprovalStatus.APPROVED : SnapshotApprovalStatus.REJECTED
-      return bulkUpdateSnapshotApprovalStatus({
+    mutationFn: async (ids: string[]) =>
+      bulkUpdateSnapshotApprovalStatus({
         snapshotIds: ids,
-        status: bulkStatusUpdate,
-      })
-    },
+        status: bulkStatus,
+      }),
     onSuccess: (res) => {
       if (res.ok) {
         queryClient.invalidateQueries({
@@ -213,7 +210,7 @@ export default function BuildDetailSnapshotPage() {
 
   const isLoading = isLoadingBuild || isLoadingSnapshots
 
-  const onBulkActionChange = (value: string) => {
+  const onBulkActionChange = (value: SnapshotApprovalStatus) => {
     if (!value) {
       return
     }

--- a/web/app/(app)/builds/[buildId]/snapshots/page.tsx
+++ b/web/app/(app)/builds/[buildId]/snapshots/page.tsx
@@ -9,14 +9,16 @@ import { toast } from 'sonner'
 
 import { useHeaderBreadcrumbs, useHeaderNavigations } from '@/components/layout/header-context'
 import { BreadcrumbItem, BreadcrumbLink, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Field } from '@/components/ui/field'
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable'
 import { Skeleton } from '@/components/ui/skeleton'
 import { DEFAULT_ERROR_DESCRIPTION, DEFAULT_ERROR_MESSAGE, snapshotsMenu } from '@/constants/app'
 import { QUERY_KEY_BUILDS, QUERY_KEY_SNAPSHOTS } from '@/constants/query-keys'
-import { BuildStatus } from '@/constants/status-map'
+import { BuildStatus, SnapshotApprovalStatus } from '@/constants/status-map'
 import { getBuildDetail, resumeBuild } from '@/features/builds/actions'
 import { BuildSummaryCard } from '@/features/builds/summary'
-import { listSnapshotsByBuildV2 } from '@/features/snapshots/actions'
+import { listSnapshotsByBuildV2, updateSnapshotApprovalStatus } from '@/features/snapshots/actions'
 import { SnapshotReviewContent } from '@/features/snapshots/review-content'
 import { SnapshotReviewFilters } from '@/features/snapshots/review-filters'
 import { SnapshotReviewTree } from '@/features/snapshots/review-tree'
@@ -31,6 +33,8 @@ export default function BuildDetailSnapshotPage() {
   const [status, setStatus] = useQueryState('status', parseAsString.withDefault(''))
   const [hideExactlyMatch, setHideExactlyMatch] = useQueryState('hideExactlyMatch', parseAsBoolean.withDefault(false))
   const [hideNewPage, setHideNewPage] = useQueryState('hideNewPage', parseAsBoolean.withDefault(false))
+  const [bulkItems, setBulkItems] = useState<string[]>([])
+  const [bulkStatus, setBulkStatus] = useState<SnapshotApprovalStatus>(SnapshotApprovalStatus.APPROVED)
 
   const queryClient = useQueryClient()
 
@@ -117,6 +121,30 @@ export default function BuildDetailSnapshotPage() {
     },
   })
 
+  const { mutate: updateBulkStatus, isPending: isBulkUpdatePending } = useMutation({
+    mutationFn: async (ids: string[]) => {
+      ids.map((i) =>
+        updateSnapshotApprovalStatus({
+          snapshotId: i,
+          status: bulkStatus,
+        }),
+      )
+    },
+    onSuccess: (res, status) => {
+      if (status) {
+        queryClient.invalidateQueries({
+          queryKey: [QUERY_KEY_SNAPSHOTS, params.buildId, 'review-tree'],
+        })
+
+        toast.success('Success updated selected items.')
+      }
+    },
+    onError: (error) => {
+      console.error(error)
+      toast.error('Bulk update status failed')
+    },
+  })
+
   const selectedSnapshotId = useMemo(() => {
     if (selectedPath) {
       return snapshotItems.find((snapshot) => snapshot.pagePath === selectedPath)?.id
@@ -170,7 +198,28 @@ export default function BuildDetailSnapshotPage() {
     }
   }
 
+  const filteredSnapshotItems = snapshotItems.filter((s) => {
+    const isExactlyMatch = isSnapshotExactlyMatching(s.diffPercentage, diffTolerancePercentage)
+    return !isExactlyMatch && s
+  })
+
+  const onBulkSelectChange = (isSelected: boolean) => {
+    if (isSelected) {
+      setBulkItems(filteredSnapshotItems.map((s) => s.id))
+    } else {
+      setBulkItems([])
+    }
+  }
+
   const isLoading = isLoadingBuild || isLoadingSnapshots
+
+  const onBulkActionChange = (value: SnapshotApprovalStatus) => {
+    if (!value) {
+      return
+    }
+    setBulkStatus(value)
+    updateBulkStatus(bulkItems)
+  }
 
   const breadcrumbs = useMemo(
     () =>
@@ -232,19 +281,28 @@ export default function BuildDetailSnapshotPage() {
         progress={processedItems}
       />
       <div className="flex h-[calc(100vh-148px)] flex-col space-y-3">
-        <SnapshotReviewFilters
-          searchQuery={searchQuery}
-          setSearchQuery={setSearchQuery}
-          browsers={browsers}
-          setBrowsers={setBrowsers}
-          status={status}
-          setStatus={setStatus}
-          hideExactlyMatch={hideExactlyMatch}
-          setHideExactlyMatch={setHideExactlyMatch}
-          hideNewPage={hideNewPage}
-          setHideNewPage={setHideNewPage}
-          diffTolerancePercentage={diffTolerancePercentage}
-        />
+        <div className="flex flex-row items-center justify-between">
+          <SnapshotReviewFilters
+            searchQuery={searchQuery}
+            setSearchQuery={setSearchQuery}
+            browsers={browsers}
+            setBrowsers={setBrowsers}
+            status={status}
+            setStatus={setStatus}
+            hideExactlyMatch={hideExactlyMatch}
+            setHideExactlyMatch={setHideExactlyMatch}
+            hideNewPage={hideNewPage}
+            setHideNewPage={setHideNewPage}
+            diffTolerancePercentage={diffTolerancePercentage}
+          />
+          <Field orientation="horizontal" className="w-xs justify-end px-4">
+            <Checkbox
+              id="bulkUpdate"
+              checked={bulkItems.length === filteredSnapshotItems.length}
+              onCheckedChange={onBulkSelectChange}
+            />
+          </Field>
+        </div>
         <ResizablePanelGroup orientation="horizontal" className="flex-1 rounded-lg border">
           <ResizablePanel collapsible minSize="12%" defaultSize="20%" maxSize="35%" className="overflow-auto">
             <SnapshotReviewTree
@@ -265,6 +323,10 @@ export default function BuildDetailSnapshotPage() {
               onChangeOpenedSnapshot={onChangeOpenedSnapshot}
               projectId={projectData?.id ?? ''}
               buildId={params.buildId}
+              bulkItems={bulkItems}
+              setBulkItems={setBulkItems}
+              onBulkActionChange={onBulkActionChange}
+              isBulkUpdatePending={isBulkUpdatePending}
             />
           </ResizablePanel>
         </ResizablePanelGroup>

--- a/web/features/snapshots/actions.ts
+++ b/web/features/snapshots/actions.ts
@@ -292,7 +292,9 @@ export async function bulkUpdateSnapshotApprovalStatus({
   status: SnapshotApprovalStatus
 }) {
   try {
-    const isValidStatus = Object.values(SnapshotApprovalStatus).includes(status)
+    const isValidStatus = Object.values([SnapshotApprovalStatus.APPROVED, SnapshotApprovalStatus.REJECTED]).includes(
+      status,
+    )
     if (!isValidStatus) {
       return { ok: false, error: 'Invalid approval status' } as const
     }

--- a/web/features/snapshots/actions.ts
+++ b/web/features/snapshots/actions.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { and, count, asc, desc, eq, ilike, type SQL, lt, gt } from 'drizzle-orm'
+import { and, count, asc, desc, eq, ilike, type SQL, lt, gt, inArray } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/pg-core'
 import { z } from 'zod'
 
@@ -273,6 +273,37 @@ export async function updateSnapshotApprovalStatus({
         .returning()
 
       const [build] = await tx.select().from(builds).where(eq(builds.id, snapshot.buildId)).limit(1)
+
+      await syncBuildStatusBasedOnSnapshotApprovals({ dbOrTx: tx, build })
+    })
+
+    return { ok: true } as const
+  } catch (error) {
+    logger.error(error)
+    return { ok: false, error: DEFAULT_ERROR_MESSAGE } as const
+  }
+}
+
+export async function bulkUpdateSnapshotApprovalStatus({
+  snapshotIds,
+  status,
+}: {
+  snapshotIds: string[]
+  status: SnapshotApprovalStatus
+}) {
+  try {
+    const isValidStatus = Object.values(SnapshotApprovalStatus).includes(status)
+    if (!isValidStatus) {
+      return { ok: false, error: 'Invalid approval status' } as const
+    }
+    await db.transaction(async (tx) => {
+      const [snapshot] = await tx
+        .update(snapshots)
+        .set({ approvalStatus: status })
+        .where(inArray(snapshots.id, snapshotIds))
+        .returning()
+
+      const [build] = await tx.select().from(builds).where(eq(builds.id, snapshot.buildId))
 
       await syncBuildStatusBasedOnSnapshotApprovals({ dbOrTx: tx, build })
     })

--- a/web/features/snapshots/review-content.tsx
+++ b/web/features/snapshots/review-content.tsx
@@ -10,7 +10,7 @@ import { Field } from '@/components/ui/field'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { BROWSER_LABEL_MAP } from '@/constants/enum'
-import { type SnapshotApprovalStatus } from '@/constants/status-map'
+import { SnapshotApprovalStatus } from '@/constants/status-map'
 import { type SnapshotDetailRes } from '@/features/snapshots/actions'
 import { SnapshotActionButtons, SnapshotViewer } from '@/features/snapshots/detail'
 import { cn, isSnapshotExactlyMatching } from '@/lib/utils'
@@ -29,7 +29,7 @@ interface SnapshotReviewContentProps {
   selectedSnapshotId?: string
   bulkItems?: string[]
   setBulkItems?: (updater: (prev: string[]) => string[]) => void
-  onBulkActionChange?: (value: string) => void
+  onBulkActionChange?: (value: SnapshotApprovalStatus) => void
   isBulkUpdatePending?: boolean
 }
 
@@ -46,7 +46,7 @@ export function SnapshotReviewContent({
   onBulkActionChange = () => {},
   isBulkUpdatePending,
 }: SnapshotReviewContentProps) {
-  const [bulkAction, setBulkAction] = useState<string>('approve')
+  const [bulkAction, setBulkAction] = useState<SnapshotApprovalStatus>(SnapshotApprovalStatus.APPROVED)
 
   useEffect(() => {
     if (!selectedSnapshotId) {
@@ -74,7 +74,7 @@ export function SnapshotReviewContent({
     return () => cancelAnimationFrame(frameId)
   }, [selectedSnapshotId])
 
-  const handleBulkActionChange = (value: string) => {
+  const handleBulkActionChange = (value: SnapshotApprovalStatus) => {
     onBulkActionChange(value)
   }
 
@@ -152,7 +152,7 @@ export function SnapshotReviewContent({
         )}
       >
         <Select
-          defaultValue="approve"
+          defaultValue={SnapshotApprovalStatus.APPROVED}
           onValueChange={(value: SnapshotApprovalStatus) => setBulkAction(value)}
           disabled={bulkItems.length === 0}
         >
@@ -161,8 +161,8 @@ export function SnapshotReviewContent({
           </SelectTrigger>
           <SelectContent>
             <SelectGroup>
-              <SelectItem value="approve">Approve</SelectItem>
-              <SelectItem value="reject">Reject</SelectItem>
+              <SelectItem value={SnapshotApprovalStatus.APPROVED}>Approve</SelectItem>
+              <SelectItem value={SnapshotApprovalStatus.REJECTED}>Reject</SelectItem>
             </SelectGroup>
           </SelectContent>
         </Select>

--- a/web/features/snapshots/review-content.tsx
+++ b/web/features/snapshots/review-content.tsx
@@ -10,7 +10,7 @@ import { Field } from '@/components/ui/field'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { BROWSER_LABEL_MAP } from '@/constants/enum'
-import { SNAPSHOT_APPROVAL_STATUS_OPTIONS, SnapshotApprovalStatus } from '@/constants/status-map'
+import { type SnapshotApprovalStatus } from '@/constants/status-map'
 import { type SnapshotDetailRes } from '@/features/snapshots/actions'
 import { SnapshotActionButtons, SnapshotViewer } from '@/features/snapshots/detail'
 import { cn, isSnapshotExactlyMatching } from '@/lib/utils'
@@ -29,7 +29,7 @@ interface SnapshotReviewContentProps {
   selectedSnapshotId?: string
   bulkItems?: string[]
   setBulkItems?: (updater: (prev: string[]) => string[]) => void
-  onBulkActionChange?: (value: SnapshotApprovalStatus) => void
+  onBulkActionChange?: (value: string) => void
   isBulkUpdatePending?: boolean
 }
 
@@ -46,7 +46,7 @@ export function SnapshotReviewContent({
   onBulkActionChange = () => {},
   isBulkUpdatePending,
 }: SnapshotReviewContentProps) {
-  const [bulkAction, setBulkAction] = useState<SnapshotApprovalStatus>(SnapshotApprovalStatus.APPROVED)
+  const [bulkAction, setBulkAction] = useState<string>('approve')
 
   useEffect(() => {
     if (!selectedSnapshotId) {
@@ -74,7 +74,7 @@ export function SnapshotReviewContent({
     return () => cancelAnimationFrame(frameId)
   }, [selectedSnapshotId])
 
-  const handleBulkActionChange = (value: SnapshotApprovalStatus) => {
+  const handleBulkActionChange = (value: string) => {
     onBulkActionChange(value)
   }
 
@@ -152,7 +152,7 @@ export function SnapshotReviewContent({
         )}
       >
         <Select
-          defaultValue={SnapshotApprovalStatus.APPROVED}
+          defaultValue="approve"
           onValueChange={(value: SnapshotApprovalStatus) => setBulkAction(value)}
           disabled={bulkItems.length === 0}
         >
@@ -161,13 +161,8 @@ export function SnapshotReviewContent({
           </SelectTrigger>
           <SelectContent>
             <SelectGroup>
-              {SNAPSHOT_APPROVAL_STATUS_OPTIONS.filter((option) => option.value !== 'pending').map(
-                ({ value, label }) => (
-                  <SelectItem key={value} value={value}>
-                    {label}
-                  </SelectItem>
-                ),
-              )}
+              <SelectItem value="approve">Approve</SelectItem>
+              <SelectItem value="reject">Reject</SelectItem>
             </SelectGroup>
           </SelectContent>
         </Select>
@@ -176,7 +171,7 @@ export function SnapshotReviewContent({
           disabled={bulkItems.length === 0 || isBulkUpdatePending || !bulkAction}
           onClick={() => handleBulkActionChange(bulkAction)}
         >
-          Apply Selected Items
+          Submit Approval
         </Button>
       </div>
     </ScrollArea>

--- a/web/features/snapshots/review-content.tsx
+++ b/web/features/snapshots/review-content.tsx
@@ -1,14 +1,19 @@
 'use client'
 
 import { ChevronDown, MessageSquare, MessageSquareDot } from 'lucide-react'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { Field } from '@/components/ui/field'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { BROWSER_LABEL_MAP } from '@/constants/enum'
+import { SNAPSHOT_APPROVAL_STATUS_OPTIONS, SnapshotApprovalStatus } from '@/constants/status-map'
 import { type SnapshotDetailRes } from '@/features/snapshots/actions'
 import { SnapshotActionButtons, SnapshotViewer } from '@/features/snapshots/detail'
+import { cn, isSnapshotExactlyMatching } from '@/lib/utils'
 
 import { SnapshotApprovalStatusBadge, SnapshotDiffBadge } from './badge'
 import { getSnapshotIcon } from './review-tree'
@@ -22,6 +27,10 @@ interface SnapshotReviewContentProps {
   onChangeOpenedSnapshot: (snapshotId: string, open: boolean) => void
   openedSnapshotIds?: string[]
   selectedSnapshotId?: string
+  bulkItems?: string[]
+  setBulkItems?: (updater: (prev: string[]) => string[]) => void
+  onBulkActionChange?: (value: SnapshotApprovalStatus) => void
+  isBulkUpdatePending?: boolean
 }
 
 export function SnapshotReviewContent({
@@ -32,7 +41,13 @@ export function SnapshotReviewContent({
   onChangeOpenedSnapshot,
   openedSnapshotIds = [],
   selectedSnapshotId,
+  bulkItems = [],
+  setBulkItems = () => {},
+  onBulkActionChange = () => {},
+  isBulkUpdatePending,
 }: SnapshotReviewContentProps) {
+  const [bulkAction, setBulkAction] = useState<SnapshotApprovalStatus>(SnapshotApprovalStatus.APPROVED)
+
   useEffect(() => {
     if (!selectedSnapshotId) {
       return
@@ -58,6 +73,10 @@ export function SnapshotReviewContent({
 
     return () => cancelAnimationFrame(frameId)
   }, [selectedSnapshotId])
+
+  const handleBulkActionChange = (value: SnapshotApprovalStatus) => {
+    onBulkActionChange(value)
+  }
 
   return (
     <ScrollArea className="h-full">
@@ -93,6 +112,20 @@ export function SnapshotReviewContent({
                       <ChevronDown className={`transition-transform ${isOpen ? 'rotate-180' : ''}`} />
                     </Button>
                   </CollapsibleTrigger>
+                  <Field orientation="horizontal">
+                    <Checkbox
+                      id="bulkUpdate"
+                      checked={bulkItems.includes(snapshot.id)}
+                      onCheckedChange={(checked) => {
+                        if (checked) {
+                          setBulkItems((prev) => [...prev, snapshot.id])
+                        } else {
+                          setBulkItems((prev) => prev.filter((id) => id !== snapshot.id))
+                        }
+                      }}
+                      disabled={isSnapshotExactlyMatching(snapshot.diffPercentage, diffTolerancePercentage)}
+                    />
+                  </Field>
                 </div>
               </div>
               <CollapsibleContent className="pt-2">
@@ -112,6 +145,40 @@ export function SnapshotReviewContent({
           </div>
         )
       })}
+      <div
+        className={cn(
+          'text-muted-foreground w-full items-end justify-end bg-black! py-5 text-sm',
+          bulkItems.length > 0 ? 'fixed right-7 bottom-0 flex' : 'hidden',
+        )}
+      >
+        <Select
+          defaultValue={SnapshotApprovalStatus.APPROVED}
+          onValueChange={(value: SnapshotApprovalStatus) => setBulkAction(value)}
+          disabled={bulkItems.length === 0}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Select action" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {SNAPSHOT_APPROVAL_STATUS_OPTIONS.filter((option) => option.value !== 'pending').map(
+                ({ value, label }) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ),
+              )}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+        <Button
+          className="ml-4"
+          disabled={bulkItems.length === 0 || isBulkUpdatePending || !bulkAction}
+          onClick={() => handleBulkActionChange(bulkAction)}
+        >
+          Apply Selected Items
+        </Button>
+      </div>
     </ScrollArea>
   )
 }


### PR DESCRIPTION
## [SP-111] Implement bulk update status in the snapshots page

## Summary

Implement bulk update in the snapshots page

## Changes

- snapshots page

## Testing

- Go to snapshots page
- Enable the checkbox on the right
- Click the action button to take the effect

## Screenshots

<img width="1814" height="1094" alt="image" src="https://github.com/user-attachments/assets/34edcdd6-144f-4e65-b53b-b31d82a53026" />
