### PR TITLE
[SP-130] Add sticky behavior for Approve/Reject buttons and filter bar

### DIFF
--- a/web/app/(app)/builds/[buildId]/snapshots/page.tsx
+++ b/web/app/(app)/builds/[buildId]/snapshots/page.tsx
@@ -276,8 +276,8 @@ export default function BuildDetailSnapshotPage() {
         isResumePending={resume.isPending}
         progress={processedItems}
       />
-      <div className="flex h-[calc(100vh-0)] flex-col space-y-3">
-        <div className="flex flex-row items-center justify-between">
+      <div className="flex h-screen flex-col space-y-3">
+        <div className="sticky top-0 z-4 flex flex-row items-center justify-between bg-white py-2 dark:bg-black">
           <SnapshotReviewFilters
             searchQuery={searchQuery}
             setSearchQuery={setSearchQuery}
@@ -299,7 +299,7 @@ export default function BuildDetailSnapshotPage() {
             />
           </Field>
         </div>
-        <ResizablePanelGroup orientation="horizontal" className="flex-1 rounded-lg border">
+        <ResizablePanelGroup orientation="horizontal" className="flex-1 overflow-visible rounded-lg border">
           <ResizablePanel collapsible minSize="12%" defaultSize="20%" maxSize="35%" className="overflow-auto">
             <SnapshotReviewTree
               snapshotItems={snapshotItems}
@@ -310,7 +310,7 @@ export default function BuildDetailSnapshotPage() {
             />
           </ResizablePanel>
           <ResizableHandle withHandle />
-          <ResizablePanel className="overflow-hidden">
+          <ResizablePanel>
             <SnapshotReviewContent
               snapshotItems={snapshotItems}
               selectedSnapshotId={selectedSnapshotId}
@@ -318,7 +318,6 @@ export default function BuildDetailSnapshotPage() {
               diffTolerancePercentage={diffTolerancePercentage}
               onChangeOpenedSnapshot={onChangeOpenedSnapshot}
               projectId={projectData?.id ?? ''}
-              buildId={params.buildId}
               bulkItems={bulkItems}
               setBulkItems={setBulkItems}
               onBulkActionChange={onBulkActionChange}

--- a/web/app/(app)/builds/[buildId]/snapshots/page.tsx
+++ b/web/app/(app)/builds/[buildId]/snapshots/page.tsx
@@ -132,6 +132,7 @@ export default function BuildDetailSnapshotPage() {
         queryClient.invalidateQueries({ queryKey: listSnapshotsByBuildQueryKey(params.buildId) })
 
         toast.success('Success updated selected items.')
+        setBulkItems([])
       }
     },
     onError: (error) => {
@@ -275,7 +276,7 @@ export default function BuildDetailSnapshotPage() {
         isResumePending={resume.isPending}
         progress={processedItems}
       />
-      <div className="flex h-[calc(100vh-148px)] flex-col space-y-3">
+      <div className="flex h-[calc(100vh-0)] flex-col space-y-3">
         <div className="flex flex-row items-center justify-between">
           <SnapshotReviewFilters
             searchQuery={searchQuery}

--- a/web/components/ui/scroll-area.tsx
+++ b/web/components/ui/scroll-area.tsx
@@ -10,7 +10,7 @@ function ScrollArea({ className, children, ...props }: React.ComponentProps<type
     <ScrollAreaPrimitive.Root data-slot="scroll-area" className={cn('relative', className)} {...props}>
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:ring-ring/50 size-full overflow-visible! rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>

--- a/web/features/snapshots/actions.ts
+++ b/web/features/snapshots/actions.ts
@@ -40,6 +40,7 @@ export async function listSnapshotsByBuildV2({ buildId }: { buildId: string }) {
   const rows = await db
     .select({
       id: snapshots.id,
+      buildId: snapshots.buildId,
       pagePath: snapshots.pagePath,
       browser: snapshots.browser,
       diffPercentage: snapshots.diffPercentage,

--- a/web/features/snapshots/detail.tsx
+++ b/web/features/snapshots/detail.tsx
@@ -1,22 +1,40 @@
 'use client'
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { CheckCircle2, XCircle, RotateCcw, RefreshCw } from 'lucide-react'
+import { CheckCircle2, XCircle, RotateCcw, RefreshCw, MessageSquareDot, MessageSquare, ChevronDown } from 'lucide-react'
 import Image from 'next/image'
 import { type ReactNode } from 'react'
 import { toast } from 'sonner'
 
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { Field } from '@/components/ui/field'
 import { Comparison, ComparisonHandle, ComparisonItem } from '@/components/ui/shadcn-io/comparison'
 import { Spinner } from '@/components/ui/spinner'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { DEFAULT_ERROR_DESCRIPTION, DEFAULT_ERROR_MESSAGE } from '@/constants/app'
-import { SNAPSHOT_VIEWER_TYPE_LABEL_MAP, SnapshotViewerType } from '@/constants/enum'
+import { BROWSER_LABEL_MAP, SNAPSHOT_VIEWER_TYPE_LABEL_MAP, SnapshotViewerType } from '@/constants/enum'
 import { detailBuildQueryKey, listSnapshotsByBuildQueryKey } from '@/constants/query-keys'
 import { SnapshotApprovalStatus } from '@/constants/status-map'
 import { retrySingleSnapshot, type MediaDetailRes, type SnapshotDetailRes } from '@/features/snapshots/actions'
 import { updateSnapshotApprovalStatus } from '@/features/snapshots/actions'
+import { cn, isSnapshotExactlyMatching } from '@/lib/utils'
+
+import { SnapshotApprovalStatusBadge, SnapshotDiffBadge } from './badge'
+import { getSnapshotIcon } from './review-tree'
+import { UpdateSnapshotNotesDialog } from './update-snapshot-notes-dialog'
+
+interface SnapshotViewerProps {
+  snapshot: SnapshotDetailRes
+  action?: ReactNode
+  buildId: string
+  isOpen: boolean
+  diffTolerancePercentage: number
+  bulkItems: string[]
+  setBulkItems: (updater: (prev: string[]) => string[]) => void
+}
 
 export function SnapshotActionButtons({
   snapshot,
@@ -162,7 +180,15 @@ const SnapshotLabels = ({ snapshot }: { snapshot: SnapshotDetailRes }) => (
   </div>
 )
 
-export function SnapshotViewer({ snapshot, action }: { snapshot: SnapshotDetailRes; action?: ReactNode }) {
+export function SnapshotViewer({
+  snapshot,
+  action,
+  buildId,
+  isOpen,
+  diffTolerancePercentage,
+  bulkItems,
+  setBulkItems,
+}: SnapshotViewerProps) {
   const dimensionMismatch =
     snapshot.baselineScreenshotMedia?.width !== snapshot.screenshotMedia?.width ||
     snapshot.baselineScreenshotMedia?.height !== snapshot.screenshotMedia?.height
@@ -181,109 +207,154 @@ export function SnapshotViewer({ snapshot, action }: { snapshot: SnapshotDetailR
 
   return (
     <Tabs defaultValue={defaultTab} className="space-y-2">
-      <div className="flex justify-between">
-        <TabsList>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-block w-fit">
-                <TabsTrigger
-                  disabled={noBaseline || dimensionMismatch ? true : undefined}
-                  value={SnapshotViewerType.HEATMAP}
-                >
-                  {SNAPSHOT_VIEWER_TYPE_LABEL_MAP[SnapshotViewerType.HEATMAP]}
-                </TabsTrigger>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent hidden={!(dimensionMismatch || noBaseline)}>
-              {noBaseline
-                ? `${SNAPSHOT_VIEWER_TYPE_LABEL_MAP[SnapshotViewerType.HEATMAP]} view is unavailable because there's no baseline screenshot to compare.`
-                : `${SNAPSHOT_VIEWER_TYPE_LABEL_MAP[SnapshotViewerType.HEATMAP]} view is unavailable due to dimension mismatch between baseline and current screenshots.`}
-            </TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-block w-fit">
-                <TabsTrigger disabled={noBaseline ? true : undefined} value={SnapshotViewerType.COMPARISON}>
-                  {SNAPSHOT_VIEWER_TYPE_LABEL_MAP[SnapshotViewerType.COMPARISON]}
-                </TabsTrigger>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent hidden={!noBaseline}>
-              {`${SNAPSHOT_VIEWER_TYPE_LABEL_MAP[SnapshotViewerType.COMPARISON]} view is unavailable because there's no baseline screenshot to compare.`}
-            </TooltipContent>
-          </Tooltip>
-          <TabsTrigger value={SnapshotViewerType.SIDE_BY_SIDE}>
-            {SNAPSHOT_VIEWER_TYPE_LABEL_MAP[SnapshotViewerType.SIDE_BY_SIDE]}
-          </TabsTrigger>
-        </TabsList>
-        {action}
+      <div className="sticky top-0 z-2 m-0! flex flex-col gap-2 bg-black py-2 text-left">
+        <div className="flex w-full justify-between gap-6">
+          <div className="flex items-center gap-2">
+            {getSnapshotIcon(snapshot, diffTolerancePercentage)}
+            <span>{`Page path ${snapshot.pagePath} on browser ${BROWSER_LABEL_MAP[snapshot.browser]}`}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <UpdateSnapshotNotesDialog buildId={buildId} snapshotId={snapshot.id} notes={snapshot.notes}>
+              <Button type="button" variant="ghost" size="icon">
+                {snapshot.notes ? <MessageSquareDot /> : <MessageSquare />}
+              </Button>
+            </UpdateSnapshotNotesDialog>
+            <SnapshotApprovalStatusBadge status={snapshot.approvalStatus} />
+            <SnapshotDiffBadge
+              diffPercentage={snapshot.diffPercentage}
+              diffTolerancePercentage={diffTolerancePercentage}
+            />
+            <CollapsibleTrigger asChild>
+              <Button type="button" variant="ghost" size="icon">
+                <ChevronDown className={`transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+              </Button>
+            </CollapsibleTrigger>
+            <Field orientation="horizontal">
+              <Checkbox
+                id="bulkUpdate"
+                checked={bulkItems.includes(snapshot.id)}
+                onCheckedChange={(checked) => {
+                  if (checked) {
+                    setBulkItems((prev) => [...prev, snapshot.id])
+                  } else {
+                    setBulkItems((prev) => prev.filter((id) => id !== snapshot.id))
+                  }
+                }}
+                disabled={isSnapshotExactlyMatching(snapshot.diffPercentage, diffTolerancePercentage)}
+              />
+            </Field>
+          </div>
+        </div>
+        <div className={cn('hidden', isOpen && 'flex justify-between')}>
+          <TabsList>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-block w-fit">
+                  <TabsTrigger
+                    disabled={noBaseline || dimensionMismatch ? true : undefined}
+                    value={SnapshotViewerType.HEATMAP}
+                  >
+                    {SNAPSHOT_VIEWER_TYPE_LABEL_MAP[SnapshotViewerType.HEATMAP]}
+                  </TabsTrigger>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent hidden={!(dimensionMismatch || noBaseline)}>
+                {noBaseline
+                  ? `${SNAPSHOT_VIEWER_TYPE_LABEL_MAP[SnapshotViewerType.HEATMAP]} view is unavailable because there's no baseline screenshot to compare.`
+                  : `${SNAPSHOT_VIEWER_TYPE_LABEL_MAP[SnapshotViewerType.HEATMAP]} view is unavailable due to dimension mismatch between baseline and current screenshots.`}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-block w-fit">
+                  <TabsTrigger disabled={noBaseline ? true : undefined} value={SnapshotViewerType.COMPARISON}>
+                    {SNAPSHOT_VIEWER_TYPE_LABEL_MAP[SnapshotViewerType.COMPARISON]}
+                  </TabsTrigger>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent hidden={!noBaseline}>
+                {`${SNAPSHOT_VIEWER_TYPE_LABEL_MAP[SnapshotViewerType.COMPARISON]} view is unavailable because there's no baseline screenshot to compare.`}
+              </TooltipContent>
+            </Tooltip>
+            <TabsTrigger value={SnapshotViewerType.SIDE_BY_SIDE}>
+              {SNAPSHOT_VIEWER_TYPE_LABEL_MAP[SnapshotViewerType.SIDE_BY_SIDE]}
+            </TabsTrigger>
+          </TabsList>
+          {action}
+        </div>
       </div>
 
-      <TabsContent value="comparison">
+      <TabsContent value="comparison" className={`${!isOpen && 'm-0'}`}>
         {snapshot.baselineScreenshotMedia === null ? (
           <PreviewFallback message="This snapshot doesn't have a baseline image to compare" />
         ) : snapshot.screenshotMedia === null ? (
           <PreviewFallback message="This snapshot doesn't have any image yet" />
         ) : (
-          <div className="flex w-full flex-col gap-2">
-            <SnapshotLabels snapshot={snapshot} />
-            <div className="bg-[url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAAK0lEQVQ4y2P8//8/A25w7949PLJMDBSAUc0jQzML/jSkpKQ0GmCjminRDADJNQjBr5nbigAAAABJRU5ErkJggg==')] bg-repeat py-0">
-              <Comparison style={{ aspectRatio }} mode="hover">
-                {/* Please note that the positions are reversed, the right position corresponds to the left side. */}
-                <ComparisonItem position="right">
-                  <Image
-                    unoptimized
-                    src={snapshot.baselineScreenshotMedia.path}
-                    alt="Baseline"
-                    width={snapshot.baselineScreenshotMedia.width || 0}
-                    height={snapshot.baselineScreenshotMedia.height || 0}
-                    className="h-auto w-full"
-                  />
-                </ComparisonItem>
-                <ComparisonItem position="left">
-                  <Image
-                    unoptimized
-                    src={snapshot.screenshotMedia.path}
-                    alt="Current"
-                    width={snapshot.screenshotMedia.width || 0}
-                    height={snapshot.screenshotMedia.height || 0}
-                    className="h-auto w-full"
-                  />
-                </ComparisonItem>
-                <ComparisonHandle />
-              </Comparison>
+          <CollapsibleContent>
+            <div className="flex w-full flex-col gap-2">
+              <SnapshotLabels snapshot={snapshot} />
+              <div className="bg-[url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAAK0lEQVQ4y2P8//8/A25w7949PLJMDBSAUc0jQzML/jSkpKQ0GmCjminRDADJNQjBr5nbigAAAABJRU5ErkJggg==')] bg-repeat py-0">
+                <Comparison style={{ aspectRatio }} mode="hover">
+                  {/* Please note that the positions are reversed, the right position corresponds to the left side. */}
+                  <ComparisonItem position="right">
+                    <Image
+                      unoptimized
+                      src={snapshot.baselineScreenshotMedia.path}
+                      alt="Baseline"
+                      width={snapshot.baselineScreenshotMedia.width || 0}
+                      height={snapshot.baselineScreenshotMedia.height || 0}
+                      className="h-auto w-full"
+                    />
+                  </ComparisonItem>
+                  <ComparisonItem position="left">
+                    <Image
+                      unoptimized
+                      src={snapshot.screenshotMedia.path}
+                      alt="Current"
+                      width={snapshot.screenshotMedia.width || 0}
+                      height={snapshot.screenshotMedia.height || 0}
+                      className="h-auto w-full"
+                    />
+                  </ComparisonItem>
+                  <ComparisonHandle />
+                </Comparison>
+              </div>
             </div>
-          </div>
+          </CollapsibleContent>
         )}
       </TabsContent>
-      <TabsContent value="heatmap">
-        <div className="w-full">
-          {snapshot.diffScreenshotMedia?.path ? (
-            <div className="relative w-full">
-              <Image
-                unoptimized
-                src={snapshot.diffScreenshotMedia?.path}
-                width={snapshot.diffScreenshotMedia?.width || 0}
-                height={snapshot.diffScreenshotMedia?.height || 0}
-                alt="Diff heatmap"
-                className="h-auto w-full"
-              />
-            </div>
-          ) : dimensionMismatch ? (
-            <PreviewFallback message="Unable to display heatmap due to dimension mismatch" />
-          ) : (
-            <PreviewFallback />
-          )}
-        </div>
-      </TabsContent>
-      <TabsContent value="side-by-side">
-        <div className="flex w-full flex-col gap-2">
-          <SnapshotLabels snapshot={snapshot} />
-          <div className="grid w-full grid-cols-2 gap-4">
-            <SnapshotImage label="Baseline" media={snapshot.baselineScreenshotMedia} />
-            <SnapshotImage label="Current" media={snapshot.screenshotMedia} />
+      <TabsContent value="heatmap" className={`${!isOpen && 'm-0'}`}>
+        <CollapsibleContent>
+          <div className="w-full">
+            {snapshot.diffScreenshotMedia?.path ? (
+              <div className="relative w-full">
+                <Image
+                  unoptimized
+                  src={snapshot.diffScreenshotMedia?.path}
+                  width={snapshot.diffScreenshotMedia?.width || 0}
+                  height={snapshot.diffScreenshotMedia?.height || 0}
+                  alt="Diff heatmap"
+                  className="h-auto w-full"
+                />
+              </div>
+            ) : dimensionMismatch ? (
+              <PreviewFallback message="Unable to display heatmap due to dimension mismatch" />
+            ) : (
+              <PreviewFallback />
+            )}
           </div>
-        </div>
+        </CollapsibleContent>
+      </TabsContent>
+      <TabsContent value="side-by-side" className={`${!isOpen && 'm-0'}`}>
+        <CollapsibleContent>
+          <div className="flex w-full flex-col gap-2">
+            <SnapshotLabels snapshot={snapshot} />
+            <div className="grid w-full grid-cols-2 gap-4">
+              <SnapshotImage label="Baseline" media={snapshot.baselineScreenshotMedia} />
+              <SnapshotImage label="Current" media={snapshot.screenshotMedia} />
+            </div>
+          </div>
+        </CollapsibleContent>
       </TabsContent>
     </Tabs>
   )

--- a/web/features/snapshots/detail.tsx
+++ b/web/features/snapshots/detail.tsx
@@ -29,7 +29,6 @@ import { UpdateSnapshotNotesDialog } from './update-snapshot-notes-dialog'
 interface SnapshotViewerProps {
   snapshot: SnapshotDetailRes
   action?: ReactNode
-  buildId: string
   isOpen: boolean
   diffTolerancePercentage: number
   bulkItems: string[]
@@ -183,7 +182,6 @@ const SnapshotLabels = ({ snapshot }: { snapshot: SnapshotDetailRes }) => (
 export function SnapshotViewer({
   snapshot,
   action,
-  buildId,
   isOpen,
   diffTolerancePercentage,
   bulkItems,
@@ -207,14 +205,14 @@ export function SnapshotViewer({
 
   return (
     <Tabs defaultValue={defaultTab} className="space-y-2">
-      <div className="sticky top-0 z-2 m-0! flex flex-col gap-2 bg-black py-2 text-left">
+      <div className="sticky top-0 z-2 m-0! flex flex-col gap-2 bg-white py-2 text-left dark:bg-black">
         <div className="flex w-full justify-between gap-6">
           <div className="flex items-center gap-2">
             {getSnapshotIcon(snapshot, diffTolerancePercentage)}
             <span>{`Page path ${snapshot.pagePath} on browser ${BROWSER_LABEL_MAP[snapshot.browser]}`}</span>
           </div>
           <div className="flex items-center gap-2">
-            <UpdateSnapshotNotesDialog buildId={buildId} snapshotId={snapshot.id} notes={snapshot.notes}>
+            <UpdateSnapshotNotesDialog buildId={snapshot.buildId} snapshotId={snapshot.id} notes={snapshot.notes}>
               <Button type="button" variant="ghost" size="icon">
                 {snapshot.notes ? <MessageSquareDot /> : <MessageSquare />}
               </Button>
@@ -284,13 +282,13 @@ export function SnapshotViewer({
         </div>
       </div>
 
-      <TabsContent value="comparison" className={`${!isOpen && 'm-0'}`}>
-        {snapshot.baselineScreenshotMedia === null ? (
-          <PreviewFallback message="This snapshot doesn't have a baseline image to compare" />
-        ) : snapshot.screenshotMedia === null ? (
-          <PreviewFallback message="This snapshot doesn't have any image yet" />
-        ) : (
-          <CollapsibleContent>
+      <CollapsibleContent>
+        <TabsContent value="comparison" className={`${!isOpen && 'm-0'}`}>
+          {snapshot.baselineScreenshotMedia === null ? (
+            <PreviewFallback message="This snapshot doesn't have a baseline image to compare" />
+          ) : snapshot.screenshotMedia === null ? (
+            <PreviewFallback message="This snapshot doesn't have any image yet" />
+          ) : (
             <div className="flex w-full flex-col gap-2">
               <SnapshotLabels snapshot={snapshot} />
               <div className="bg-[url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAAK0lEQVQ4y2P8//8/A25w7949PLJMDBSAUc0jQzML/jSkpKQ0GmCjminRDADJNQjBr5nbigAAAABJRU5ErkJggg==')] bg-repeat py-0">
@@ -320,11 +318,9 @@ export function SnapshotViewer({
                 </Comparison>
               </div>
             </div>
-          </CollapsibleContent>
-        )}
-      </TabsContent>
-      <TabsContent value="heatmap" className={`${!isOpen && 'm-0'}`}>
-        <CollapsibleContent>
+          )}
+        </TabsContent>
+        <TabsContent value="heatmap" className={`${!isOpen && 'm-0'}`}>
           <div className="w-full">
             {snapshot.diffScreenshotMedia?.path ? (
               <div className="relative w-full">
@@ -343,10 +339,8 @@ export function SnapshotViewer({
               <PreviewFallback />
             )}
           </div>
-        </CollapsibleContent>
-      </TabsContent>
-      <TabsContent value="side-by-side" className={`${!isOpen && 'm-0'}`}>
-        <CollapsibleContent>
+        </TabsContent>
+        <TabsContent value="side-by-side" className={`${!isOpen && 'm-0'}`}>
           <div className="flex w-full flex-col gap-2">
             <SnapshotLabels snapshot={snapshot} />
             <div className="grid w-full grid-cols-2 gap-4">
@@ -354,8 +348,8 @@ export function SnapshotViewer({
               <SnapshotImage label="Current" media={snapshot.screenshotMedia} />
             </div>
           </div>
-        </CollapsibleContent>
-      </TabsContent>
+        </TabsContent>
+      </CollapsibleContent>
     </Tabs>
   )
 }

--- a/web/features/snapshots/review-content.tsx
+++ b/web/features/snapshots/review-content.tsx
@@ -14,7 +14,6 @@ import { cn } from '@/lib/utils'
 interface SnapshotReviewContentProps {
   snapshotItems: SnapshotDetailRes[]
   projectId: string
-  buildId: string
   diffTolerancePercentage: number
   onChangeOpenedSnapshot: (snapshotId: string, open: boolean) => void
   openedSnapshotIds?: string[]
@@ -28,7 +27,6 @@ interface SnapshotReviewContentProps {
 export function SnapshotReviewContent({
   snapshotItems,
   projectId,
-  buildId,
   diffTolerancePercentage,
   onChangeOpenedSnapshot,
   openedSnapshotIds = [],
@@ -81,7 +79,6 @@ export function SnapshotReviewContent({
               <SnapshotViewer
                 snapshot={snapshot}
                 isOpen={isOpen}
-                buildId={buildId}
                 diffTolerancePercentage={diffTolerancePercentage}
                 bulkItems={bulkItems}
                 setBulkItems={setBulkItems}
@@ -89,7 +86,7 @@ export function SnapshotReviewContent({
                   <SnapshotActionButtons
                     snapshot={snapshot}
                     projectId={projectId}
-                    buildId={buildId}
+                    buildId={snapshot.buildId}
                     snapshotId={snapshot.id}
                   />
                 }
@@ -100,7 +97,7 @@ export function SnapshotReviewContent({
       })}
       <div
         className={cn(
-          'text-muted-foreground w-full items-end justify-end bg-black! py-5 text-sm',
+          'text-muted-foreground z-10 w-full items-end justify-end bg-white py-5 text-sm dark:bg-black!',
           bulkItems.length > 0 ? 'fixed right-7 bottom-0 flex' : 'hidden',
         )}
       >

--- a/web/features/snapshots/review-content.tsx
+++ b/web/features/snapshots/review-content.tsx
@@ -1,23 +1,15 @@
 'use client'
 
-import { ChevronDown, MessageSquare, MessageSquareDot } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
-import { Checkbox } from '@/components/ui/checkbox'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
-import { Field } from '@/components/ui/field'
+import { Collapsible } from '@/components/ui/collapsible'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { BROWSER_LABEL_MAP } from '@/constants/enum'
 import { SnapshotApprovalStatus } from '@/constants/status-map'
 import { type SnapshotDetailRes } from '@/features/snapshots/actions'
 import { SnapshotActionButtons, SnapshotViewer } from '@/features/snapshots/detail'
-import { cn, isSnapshotExactlyMatching } from '@/lib/utils'
-
-import { SnapshotApprovalStatusBadge, SnapshotDiffBadge } from './badge'
-import { getSnapshotIcon } from './review-tree'
-import { UpdateSnapshotNotesDialog } from './update-snapshot-notes-dialog'
+import { cn } from '@/lib/utils'
 
 interface SnapshotReviewContentProps {
   snapshotItems: SnapshotDetailRes[]
@@ -79,63 +71,29 @@ export function SnapshotReviewContent({
   }
 
   return (
-    <ScrollArea className="h-full">
+    <ScrollArea className={cn('h-full', openedSnapshotIds.length && 'h-[98vh]!')}>
       {snapshotItems.map((snapshot) => {
         const isOpen = openedSnapshotIds.includes(snapshot.id)
 
         return (
           <div key={snapshot.id} id={`snapshot-${snapshot.id}`} className="border-b px-4 last:border-b-0">
             <Collapsible open={isOpen} onOpenChange={(open) => onChangeOpenedSnapshot(snapshot.id, open)}>
-              <div className="flex w-full justify-between gap-6 py-2 text-left">
-                <div className="flex items-center gap-2">
-                  {getSnapshotIcon(snapshot, diffTolerancePercentage)}
-                  <span>{`Page path ${snapshot.pagePath} on browser ${BROWSER_LABEL_MAP[snapshot.browser]}`}</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <UpdateSnapshotNotesDialog buildId={buildId} snapshotId={snapshot.id} notes={snapshot.notes}>
-                    <Button type="button" variant="ghost" size="icon">
-                      {snapshot.notes ? <MessageSquareDot /> : <MessageSquare />}
-                    </Button>
-                  </UpdateSnapshotNotesDialog>
-                  <SnapshotApprovalStatusBadge status={snapshot.approvalStatus} />
-                  <SnapshotDiffBadge
-                    diffPercentage={snapshot.diffPercentage}
-                    diffTolerancePercentage={diffTolerancePercentage}
+              <SnapshotViewer
+                snapshot={snapshot}
+                isOpen={isOpen}
+                buildId={buildId}
+                diffTolerancePercentage={diffTolerancePercentage}
+                bulkItems={bulkItems}
+                setBulkItems={setBulkItems}
+                action={
+                  <SnapshotActionButtons
+                    snapshot={snapshot}
+                    projectId={projectId}
+                    buildId={buildId}
+                    snapshotId={snapshot.id}
                   />
-                  <CollapsibleTrigger asChild>
-                    <Button type="button" variant="ghost" size="icon">
-                      <ChevronDown className={`transition-transform ${isOpen ? 'rotate-180' : ''}`} />
-                    </Button>
-                  </CollapsibleTrigger>
-                  <Field orientation="horizontal">
-                    <Checkbox
-                      id="bulkUpdate"
-                      checked={bulkItems.includes(snapshot.id)}
-                      onCheckedChange={(checked) => {
-                        if (checked) {
-                          setBulkItems((prev) => [...prev, snapshot.id])
-                        } else {
-                          setBulkItems((prev) => prev.filter((id) => id !== snapshot.id))
-                        }
-                      }}
-                      disabled={isSnapshotExactlyMatching(snapshot.diffPercentage, diffTolerancePercentage)}
-                    />
-                  </Field>
-                </div>
-              </div>
-              <CollapsibleContent className="pt-2">
-                <SnapshotViewer
-                  snapshot={snapshot}
-                  action={
-                    <SnapshotActionButtons
-                      snapshot={snapshot}
-                      projectId={projectId}
-                      buildId={buildId}
-                      snapshotId={snapshot.id}
-                    />
-                  }
-                />
-              </CollapsibleContent>
+                }
+              />
             </Collapsible>
           </div>
         )


### PR DESCRIPTION
## Fixes #130 Add sticky behaviour for approve/reject button and filter

## Summary

Add sticky behaviour for the approve/reject button

## Changes

- Snapshots page
- Snapshot detail
- Snapshot element review content

## Testing

- Go to  the snapshots page
- In the scroll area snapshots result, the header and the approve/reject button should be sticky

## Screenshots


<img width="2726" height="956" alt="image" src="https://github.com/user-attachments/assets/c1836f34-fd22-4474-9946-23ce76b007dd" />
