### PR TITLE
[SP-131] Enhance build page warning message and labels

### DIFF
--- a/web/app/(app)/builds/[buildId]/snapshots/page.tsx
+++ b/web/app/(app)/builds/[buildId]/snapshots/page.tsx
@@ -57,6 +57,7 @@ export default function BuildDetailSnapshotPage() {
   })
 
   const buildData = data?.build
+  const baselineBuildData = data?.baselineBuild
   const diffTolerancePercentage = buildData?.diffTolerancePercentage ?? 0
   const projectData = data?.project
 
@@ -322,6 +323,8 @@ export default function BuildDetailSnapshotPage() {
               setBulkItems={setBulkItems}
               onBulkActionChange={onBulkActionChange}
               isBulkUpdatePending={isBulkUpdatePending}
+              build={buildData}
+              baselineBuildData={baselineBuildData}
             />
           </ResizablePanel>
         </ResizablePanelGroup>

--- a/web/constants/app.ts
+++ b/web/constants/app.ts
@@ -63,12 +63,12 @@ export const DEFAULT_SNAPSHOTS_SELECTOR = 'body'
 
 export const PAGE_SIZE_OPTIONS = [6, 12, 24, 48]
 
-export const DAYS_THRESHOLD = 7
-export const DAYS_THRESHOLD_IN_MS = DAYS_THRESHOLD * 24 * 60 * 60 * 1000
+export const BUILD_OUTDATED_THRESHOLD_IN_DAYS = 7
+export const BUILD_OUTDATED_THRESHOLD_IN_MS = BUILD_OUTDATED_THRESHOLD_IN_DAYS * 24 * 60 * 60 * 1000
 
-export const DAYS_THRESHOLD_LABEL = formatDuration(
+export const BUILD_OUTDATED_THRESHOLD_LABEL = formatDuration(
   intervalToDuration({
     start: 0,
-    end: DAYS_THRESHOLD * 24 * 60 * 60 * 1000,
+    end: BUILD_OUTDATED_THRESHOLD_IN_DAYS * 24 * 60 * 60 * 1000,
   }),
 )

--- a/web/constants/app.ts
+++ b/web/constants/app.ts
@@ -1,3 +1,5 @@
+import { formatDuration } from 'date-fns'
+import { intervalToDuration } from 'date-fns/intervalToDuration'
 import { type Route } from 'next'
 
 import { Browser } from '@/constants/enum'
@@ -60,3 +62,13 @@ export const DEFAULT_SNAPSHOTS_BROWSER = Browser.CHROME
 export const DEFAULT_SNAPSHOTS_SELECTOR = 'body'
 
 export const PAGE_SIZE_OPTIONS = [6, 12, 24, 48]
+
+export const DAYS_THRESHOLD = 7
+export const DAYS_THRESHOLD_IN_MS = DAYS_THRESHOLD * 24 * 60 * 60 * 1000
+
+export const DAYS_THRESHOLD_LABEL = formatDuration(
+  intervalToDuration({
+    start: 0,
+    end: DAYS_THRESHOLD * 24 * 60 * 60 * 1000,
+  }),
+)

--- a/web/features/builds/actions.ts
+++ b/web/features/builds/actions.ts
@@ -72,7 +72,7 @@ export async function listBuildsByProject({
 
   const countQuery = db.select({ total: count() }).from(builds).where(where)
 
-  const baselineQuery = await getBaselineBuild({ projectId })
+  const baselineQuery = await getBaselineBuild({ dbOrTx: db, projectId })
 
   const [rows, [{ total }], baseline] = await Promise.all([rowsQuery, countQuery, baselineQuery])
 
@@ -193,7 +193,7 @@ export async function getBuildDetail({ buildId }: { buildId: string }) {
 
   if (!project) return null
 
-  const baselineBuild = await getBaselineBuild({ projectId: project.id })
+  const baselineBuild = await getBaselineBuild({ dbOrTx: db, projectId: project.id })
 
   if (!baselineBuild) return null
 
@@ -357,25 +357,11 @@ export async function syncBuildStatusBasedOnSnapshotApprovals({
   await dbOrTx.update(builds).set({ status: build.status }).where(eq(builds.id, build.id))
 
   // Find baseline build for the snapshot's build
-  const [latestApprovedBuild] = await dbOrTx
-    .select()
-    .from(builds)
-    .where(
-      and(
-        eq(builds.projectId, build.projectId),
-        eq(builds.status, BuildStatus.PASSED),
-        // Only consider builds with the same base URL as the baseline build,
-        // to prevent special builds (with different base URLs) from becoming baseline builds.
-        eq(builds.baseUrl, projects.baseUrl),
-      ),
-    )
-    .leftJoin(projects, eq(builds.projectId, projects.id))
-    .orderBy(desc(builds.createdAt))
-    .limit(1)
+  const latestApprovedBuild = await getBaselineBuild({ dbOrTx: db, projectId: build.projectId })
   if (latestApprovedBuild) {
     await dbOrTx
       .update(projects)
-      .set({ baselineBuildId: latestApprovedBuild.builds.id })
+      .set({ baselineBuildId: latestApprovedBuild.id })
       .where(eq(projects.id, build.projectId))
   }
 
@@ -594,11 +580,11 @@ export async function calculateExpectedSnapshotCount({ project }: { project?: ty
   return totalProcessedPage
 }
 
-export async function getBaselineBuild({ projectId }: { projectId: string }) {
+export async function getBaselineBuild({ dbOrTx, projectId }: { dbOrTx: DB | DBTransaction; projectId: string }) {
   if (!projectId) {
     return null
   }
-  const [row] = await db
+  const [row] = await dbOrTx
     .select()
     .from(builds)
     .where(

--- a/web/features/builds/actions.ts
+++ b/web/features/builds/actions.ts
@@ -72,9 +72,11 @@ export async function listBuildsByProject({
 
   const countQuery = db.select({ total: count() }).from(builds).where(where)
 
-  const [rows, [{ total }]] = await Promise.all([rowsQuery, countQuery])
+  const baselineQuery = await getBaselineBuild({ projectId })
 
-  return { data: rows, total }
+  const [rows, [{ total }], baseline] = await Promise.all([rowsQuery, countQuery, baselineQuery])
+
+  return { data: rows, total, baseline }
 }
 
 export async function getNovuSubscribers() {
@@ -191,9 +193,14 @@ export async function getBuildDetail({ buildId }: { buildId: string }) {
 
   if (!project) return null
 
+  const baselineBuild = await getBaselineBuild({ projectId: project.id })
+
+  if (!baselineBuild) return null
+
   const result = {
     build,
     project,
+    baselineBuild,
   }
   return result
 }
@@ -585,4 +592,27 @@ export async function calculateExpectedSnapshotCount({ project }: { project?: ty
     totalProcessedPage += totalRules
   }
   return totalProcessedPage
+}
+
+export async function getBaselineBuild({ projectId }: { projectId: string }) {
+  if (!projectId) {
+    return null
+  }
+  const [row] = await db
+    .select()
+    .from(builds)
+    .where(
+      and(
+        eq(builds.projectId, projectId),
+        eq(builds.status, BuildStatus.PASSED),
+        // Only consider builds with the same base URL as the baseline build,
+        // to prevent special builds (with different base URLs) from becoming baseline builds.
+        eq(builds.baseUrl, projects.baseUrl),
+      ),
+    )
+    .leftJoin(projects, eq(builds.projectId, projects.id))
+    .orderBy(desc(builds.createdAt))
+    .limit(1)
+
+  return row.builds
 }

--- a/web/features/builds/list.tsx
+++ b/web/features/builds/list.tsx
@@ -71,7 +71,11 @@ export function BuildListCard({ projectId, projectBaseUrl }: { projectId?: strin
         </div>
 
         {projectId && projectBaseUrl ? (
-          <TriggerBuildDialog projectId={projectId} baseUrl={projectBaseUrl}>
+          <TriggerBuildDialog
+            projectId={projectId}
+            baseUrl={projectBaseUrl}
+            baselineBuild={data?.baseline || undefined}
+          >
             <Button size="sm">
               <Play /> Trigger Build
             </Button>

--- a/web/features/builds/trigger-build-dialog.tsx
+++ b/web/features/builds/trigger-build-dialog.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { InfoIcon } from 'lucide-react'
-import { type ReactNode, useState } from 'react'
+import { InfoIcon, TriangleAlert } from 'lucide-react'
+import Link from 'next/link'
+import { type MouseEvent, type ReactNode, useState } from 'react'
 import { toast } from 'sonner'
 
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -16,6 +17,8 @@ import {
 } from '@/components/ui/dialog'
 import { DEFAULT_ERROR_DESCRIPTION, DEFAULT_ERROR_MESSAGE } from '@/constants/app'
 import { listBuildsByProjectQueryKey } from '@/constants/query-keys'
+import { type builds } from '@/db/schema'
+import { isBaselineExpired } from '@/lib/utils'
 
 import { triggerBuildManual } from './actions'
 import { TriggerBuildForm } from './form'
@@ -25,13 +28,16 @@ export function TriggerBuildDialog({
   projectId,
   baseUrl,
   children,
+  baselineBuild,
 }: {
   children: ReactNode
   projectId: string
   baseUrl: string
+  baselineBuild?: typeof builds.$inferSelect
 }) {
   const queryClient = useQueryClient()
   const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const baselineExpired = baselineBuild && isBaselineExpired(baselineBuild.createdAt)
   const triggerBuildMutation = useMutation({
     mutationFn: (values: { projectId: string; payload: TriggerBuildInput }) => triggerBuildManual(values),
     onSuccess: (res, variables) => {
@@ -50,6 +56,15 @@ export function TriggerBuildDialog({
     },
   })
 
+  const handleTriggerBaseline = (e: MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDialogOpen(false)
+
+    const payload = { baseUrl }
+    triggerBuildMutation.mutate({ projectId, payload })
+  }
+
   return (
     <>
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
@@ -61,13 +76,30 @@ export function TriggerBuildDialog({
               Trigger a new build for this project. You can optionally provide a custom Base URL to test against.
             </DialogDescription>
           </DialogHeader>
+          {baselineExpired && (
+            <Alert className="border-amber-200 bg-amber-50/50 dark:border-amber-900/50 dark:bg-amber-950/30">
+              <TriangleAlert className="size-4 text-amber-600 dark:text-amber-400" />
+
+              <AlertTitle className="text-amber-900 dark:text-amber-100">Baseline Refresh Recommended</AlertTitle>
+
+              <AlertDescription className="text-amber-800/90 dark:text-amber-200/90">
+                <div>
+                  This baseline was last updated <span className="font-bold">7 days ago</span>. Consider approving a
+                  newer baseline to keep visual comparisons accurate.{' '}
+                  <Link href="#" onClick={(e) => handleTriggerBaseline(e)} className="font-bold underline">
+                    Trigger new baseline
+                  </Link>
+                </div>
+              </AlertDescription>
+            </Alert>
+          )}
           <Alert className="border-blue-200 bg-blue-50/50 dark:border-blue-900/50 dark:bg-blue-950/30">
             <InfoIcon className="size-4 text-blue-600 dark:text-blue-400" />
             <AlertTitle className="text-blue-900 dark:text-blue-100">Custom Base URL Notice</AlertTitle>
             <AlertDescription className="text-blue-800/90 dark:text-blue-200/90">
               <div>
                 Providing a different Base URL will trigger a <span className="font-bold">custom build</span>. A custom
-                build with status &quot;Test Passed&quot; will <span className="font-bold">not update</span> your
+                build with status &quot;Test Passed&quot; will <span className="font-bold">not update </span> your
                 project&apos;s baseline build.
               </div>
             </AlertDescription>

--- a/web/features/builds/trigger-build-dialog.tsx
+++ b/web/features/builds/trigger-build-dialog.tsx
@@ -15,7 +15,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import { DAYS_THRESHOLD_LABEL, DEFAULT_ERROR_DESCRIPTION, DEFAULT_ERROR_MESSAGE } from '@/constants/app'
+import { BUILD_OUTDATED_THRESHOLD_LABEL, DEFAULT_ERROR_DESCRIPTION, DEFAULT_ERROR_MESSAGE } from '@/constants/app'
 import { listBuildsByProjectQueryKey } from '@/constants/query-keys'
 import { type builds } from '@/db/schema'
 import { isBaselineOutdated } from '@/lib/utils'
@@ -82,10 +82,10 @@ export function TriggerBuildDialog({
 
               <AlertDescription className="text-amber-800/90 dark:text-amber-200/90">
                 <div>
-                  This baseline was last updated <span className="font-bold">{DAYS_THRESHOLD_LABEL} ago</span>. Consider
-                  approving a newer baseline to keep visual comparisons accurate.{' '}
+                  This baseline was last updated <span className="font-bold">{BUILD_OUTDATED_THRESHOLD_LABEL} ago</span>
+                  . Consider approving a newer baseline to keep visual comparisons accurate.{' '}
                   <Button
-                    variant="ghost"
+                    variant="link"
                     className="hover:transparent h-max w-fit cursor-pointer p-1 py-0 font-bold underline"
                     type="button"
                     onClick={handleTriggerBaseline}

--- a/web/features/builds/trigger-build-dialog.tsx
+++ b/web/features/builds/trigger-build-dialog.tsx
@@ -2,11 +2,11 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { InfoIcon, TriangleAlert } from 'lucide-react'
-import Link from 'next/link'
-import { type MouseEvent, type ReactNode, useState } from 'react'
+import { type ReactNode, useState } from 'react'
 import { toast } from 'sonner'
 
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
@@ -15,10 +15,10 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import { DEFAULT_ERROR_DESCRIPTION, DEFAULT_ERROR_MESSAGE } from '@/constants/app'
+import { DAYS_THRESHOLD_LABEL, DEFAULT_ERROR_DESCRIPTION, DEFAULT_ERROR_MESSAGE } from '@/constants/app'
 import { listBuildsByProjectQueryKey } from '@/constants/query-keys'
 import { type builds } from '@/db/schema'
-import { isBaselineExpired } from '@/lib/utils'
+import { isBaselineOutdated } from '@/lib/utils'
 
 import { triggerBuildManual } from './actions'
 import { TriggerBuildForm } from './form'
@@ -37,7 +37,7 @@ export function TriggerBuildDialog({
 }) {
   const queryClient = useQueryClient()
   const [isDialogOpen, setIsDialogOpen] = useState(false)
-  const baselineExpired = baselineBuild && isBaselineExpired(baselineBuild.createdAt)
+  const baselineExpired = baselineBuild && isBaselineOutdated(baselineBuild.createdAt)
   const triggerBuildMutation = useMutation({
     mutationFn: (values: { projectId: string; payload: TriggerBuildInput }) => triggerBuildManual(values),
     onSuccess: (res, variables) => {
@@ -56,9 +56,7 @@ export function TriggerBuildDialog({
     },
   })
 
-  const handleTriggerBaseline = (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault()
-    e.stopPropagation()
+  const handleTriggerBaseline = () => {
     setIsDialogOpen(false)
 
     const payload = { baseUrl }
@@ -84,11 +82,16 @@ export function TriggerBuildDialog({
 
               <AlertDescription className="text-amber-800/90 dark:text-amber-200/90">
                 <div>
-                  This baseline was last updated <span className="font-bold">7 days ago</span>. Consider approving a
-                  newer baseline to keep visual comparisons accurate.{' '}
-                  <Link href="#" onClick={(e) => handleTriggerBaseline(e)} className="font-bold underline">
+                  This baseline was last updated <span className="font-bold">{DAYS_THRESHOLD_LABEL} ago</span>. Consider
+                  approving a newer baseline to keep visual comparisons accurate.{' '}
+                  <Button
+                    variant="ghost"
+                    className="hover:transparent h-max w-fit cursor-pointer p-1 py-0 font-bold underline"
+                    type="button"
+                    onClick={handleTriggerBaseline}
+                  >
                     Trigger new baseline
-                  </Link>
+                  </Button>
                 </div>
               </AlertDescription>
             </Alert>

--- a/web/features/snapshots/detail.tsx
+++ b/web/features/snapshots/detail.tsx
@@ -215,9 +215,7 @@ const SnapshotLabelInfo = ({ build }: { build?: typeof builds.$inferSelect | nul
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-fit px-2 py-1.5 text-xs">
-        <span>
-          {build?.identifier} - {formatDateTime(build?.createdAt ?? '')}
-        </span>
+        {build?.identifier} - {formatDateTime(build?.createdAt ?? '')}
       </PopoverContent>
     </Popover>
   )

--- a/web/features/snapshots/detail.tsx
+++ b/web/features/snapshots/detail.tsx
@@ -1,7 +1,16 @@
 'use client'
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { CheckCircle2, XCircle, RotateCcw, RefreshCw, MessageSquareDot, MessageSquare, ChevronDown } from 'lucide-react'
+import {
+  CheckCircle2,
+  XCircle,
+  RotateCcw,
+  RefreshCw,
+  MessageSquareDot,
+  MessageSquare,
+  ChevronDown,
+  InfoIcon,
+} from 'lucide-react'
 import Image from 'next/image'
 import { type ReactNode } from 'react'
 import { toast } from 'sonner'
@@ -10,6 +19,7 @@ import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Field } from '@/components/ui/field'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Comparison, ComparisonHandle, ComparisonItem } from '@/components/ui/shadcn-io/comparison'
 import { Spinner } from '@/components/ui/spinner'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -18,15 +28,18 @@ import { DEFAULT_ERROR_DESCRIPTION, DEFAULT_ERROR_MESSAGE } from '@/constants/ap
 import { BROWSER_LABEL_MAP, SNAPSHOT_VIEWER_TYPE_LABEL_MAP, SnapshotViewerType } from '@/constants/enum'
 import { detailBuildQueryKey, listSnapshotsByBuildQueryKey } from '@/constants/query-keys'
 import { SnapshotApprovalStatus } from '@/constants/status-map'
+import { type builds } from '@/db/schema/project'
 import { retrySingleSnapshot, type MediaDetailRes, type SnapshotDetailRes } from '@/features/snapshots/actions'
 import { updateSnapshotApprovalStatus } from '@/features/snapshots/actions'
-import { cn, isSnapshotExactlyMatching } from '@/lib/utils'
+import { cn, formatDateTime, isSnapshotExactlyMatching } from '@/lib/utils'
 
 import { SnapshotApprovalStatusBadge, SnapshotDiffBadge } from './badge'
 import { getSnapshotIcon } from './review-tree'
 import { UpdateSnapshotNotesDialog } from './update-snapshot-notes-dialog'
 
 interface SnapshotViewerProps {
+  build?: typeof builds.$inferSelect | null
+  baselineBuild?: typeof builds.$inferSelect | null
   snapshot: SnapshotDetailRes
   action?: ReactNode
   isOpen: boolean
@@ -172,14 +185,47 @@ const SnapshotLabel = ({ children, media }: { children: ReactNode; media?: Media
   return <span>{`${children} (${media?.width || 0}x${media?.height || 0})`}</span>
 }
 
-const SnapshotLabels = ({ snapshot }: { snapshot: SnapshotDetailRes }) => (
+const SnapshotLabels = ({
+  snapshot,
+  build,
+  baselineBuild,
+}: {
+  snapshot: SnapshotDetailRes
+  build?: typeof builds.$inferSelect | null
+  baselineBuild?: typeof builds.$inferSelect | null
+}) => (
   <div className="text-muted-foreground flex justify-between text-xs">
-    <SnapshotLabel media={snapshot.baselineScreenshotMedia}>Baseline</SnapshotLabel>
-    <SnapshotLabel media={snapshot.screenshotMedia}>Current</SnapshotLabel>
+    <div className="flex items-center gap-0.5">
+      <SnapshotLabel media={snapshot.baselineScreenshotMedia}>Baseline</SnapshotLabel>
+      {baselineBuild && <SnapshotLabelInfo build={baselineBuild} />}
+    </div>
+    <div className="flex items-center gap-0.5">
+      <SnapshotLabel media={snapshot.screenshotMedia}>Current</SnapshotLabel>
+      <SnapshotLabelInfo build={build} />
+    </div>
   </div>
 )
 
+const SnapshotLabelInfo = ({ build }: { build?: typeof builds.$inferSelect | null }) => {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="icon">
+          <InfoIcon />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-fit px-2 py-1.5 text-xs">
+        <span>
+          {build?.identifier} - {formatDateTime(build?.createdAt ?? '')}
+        </span>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
 export function SnapshotViewer({
+  build,
+  baselineBuild,
   snapshot,
   action,
   isOpen,
@@ -205,7 +251,7 @@ export function SnapshotViewer({
 
   return (
     <Tabs defaultValue={defaultTab} className="space-y-2">
-      <div className="sticky top-0 z-2 m-0! flex flex-col gap-2 bg-white py-2 text-left dark:bg-black">
+      <div className="sticky top-0 z-100! m-0! flex flex-col gap-2 bg-white py-2 text-left dark:bg-black">
         <div className="flex w-full justify-between gap-6">
           <div className="flex items-center gap-2">
             {getSnapshotIcon(snapshot, diffTolerancePercentage)}
@@ -290,7 +336,7 @@ export function SnapshotViewer({
             <PreviewFallback message="This snapshot doesn't have any image yet" />
           ) : (
             <div className="flex w-full flex-col gap-2">
-              <SnapshotLabels snapshot={snapshot} />
+              <SnapshotLabels snapshot={snapshot} build={build} baselineBuild={baselineBuild} />
               <div className="bg-[url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAAK0lEQVQ4y2P8//8/A25w7949PLJMDBSAUc0jQzML/jSkpKQ0GmCjminRDADJNQjBr5nbigAAAABJRU5ErkJggg==')] bg-repeat py-0">
                 <Comparison style={{ aspectRatio }} mode="hover">
                   {/* Please note that the positions are reversed, the right position corresponds to the left side. */}
@@ -342,7 +388,7 @@ export function SnapshotViewer({
         </TabsContent>
         <TabsContent value="side-by-side" className={`${!isOpen && 'm-0'}`}>
           <div className="flex w-full flex-col gap-2">
-            <SnapshotLabels snapshot={snapshot} />
+            <SnapshotLabels snapshot={snapshot} build={build} />
             <div className="grid w-full grid-cols-2 gap-4">
               <SnapshotImage label="Baseline" media={snapshot.baselineScreenshotMedia} />
               <SnapshotImage label="Current" media={snapshot.screenshotMedia} />

--- a/web/features/snapshots/review-content.tsx
+++ b/web/features/snapshots/review-content.tsx
@@ -7,6 +7,7 @@ import { Collapsible } from '@/components/ui/collapsible'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { SnapshotApprovalStatus } from '@/constants/status-map'
+import { type builds } from '@/db/schema/project'
 import { type SnapshotDetailRes } from '@/features/snapshots/actions'
 import { SnapshotActionButtons, SnapshotViewer } from '@/features/snapshots/detail'
 import { cn } from '@/lib/utils'
@@ -22,6 +23,8 @@ interface SnapshotReviewContentProps {
   setBulkItems?: (updater: (prev: string[]) => string[]) => void
   onBulkActionChange?: (value: SnapshotApprovalStatus) => void
   isBulkUpdatePending?: boolean
+  build?: typeof builds.$inferSelect | null
+  baselineBuildData?: typeof builds.$inferSelect | null
 }
 
 export function SnapshotReviewContent({
@@ -35,6 +38,8 @@ export function SnapshotReviewContent({
   setBulkItems = () => {},
   onBulkActionChange = () => {},
   isBulkUpdatePending,
+  build,
+  baselineBuildData,
 }: SnapshotReviewContentProps) {
   const [bulkAction, setBulkAction] = useState<SnapshotApprovalStatus>(SnapshotApprovalStatus.APPROVED)
 
@@ -77,6 +82,8 @@ export function SnapshotReviewContent({
           <div key={snapshot.id} id={`snapshot-${snapshot.id}`} className="border-b px-4 last:border-b-0">
             <Collapsible open={isOpen} onOpenChange={(open) => onChangeOpenedSnapshot(snapshot.id, open)}>
               <SnapshotViewer
+                build={build}
+                baselineBuild={baselineBuildData}
                 snapshot={snapshot}
                 isOpen={isOpen}
                 diffTolerancePercentage={diffTolerancePercentage}

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -2,9 +2,11 @@ import * as crypto from 'crypto'
 
 import { type AnyFormApi } from '@tanstack/react-form'
 import { clsx, type ClassValue } from 'clsx'
-import { format } from 'date-fns'
+import { differenceInDays, format } from 'date-fns'
 import { twMerge } from 'tailwind-merge'
 import { type $ZodFlattenedError } from 'zod/v4/core'
+
+import { DAYS_THRESHOLD } from '@/constants/app'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -63,12 +65,13 @@ export function isSnapshotExactlyMatching(diffPercentage: number, tolerancePerce
   return diffPercentage <= (tolerancePercentage ?? 0)
 }
 
-export const isBaselineExpired = (date: Date | string): boolean => {
+export const isBaselineOutdated = (date: Date | string): boolean => {
   const targetDate = new Date(date)
   const now = new Date()
 
-  const diff = now.getTime() - targetDate.getTime()
-  const oneDay = 7 * 24 * 60 * 60 * 1000
+  const diffInDays = differenceInDays(now, targetDate)
 
-  return diff >= oneDay
+  const isWithinThreshold = diffInDays <= DAYS_THRESHOLD
+
+  return !isWithinThreshold
 }

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -6,7 +6,7 @@ import { differenceInDays, format } from 'date-fns'
 import { twMerge } from 'tailwind-merge'
 import { type $ZodFlattenedError } from 'zod/v4/core'
 
-import { DAYS_THRESHOLD } from '@/constants/app'
+import { BUILD_OUTDATED_THRESHOLD_IN_DAYS } from '@/constants/app'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -71,7 +71,7 @@ export const isBaselineOutdated = (date: Date | string): boolean => {
 
   const diffInDays = differenceInDays(now, targetDate)
 
-  const isWithinThreshold = diffInDays <= DAYS_THRESHOLD
+  const isWithinThreshold = diffInDays <= BUILD_OUTDATED_THRESHOLD_IN_DAYS
 
   return !isWithinThreshold
 }

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -62,3 +62,13 @@ export const sha256Hex = (input: string) =>
 export function isSnapshotExactlyMatching(diffPercentage: number, tolerancePercentage?: number | null) {
   return diffPercentage <= (tolerancePercentage ?? 0)
 }
+
+export const isBaselineExpired = (date: Date | string): boolean => {
+  const targetDate = new Date(date)
+  const now = new Date()
+
+  const diff = now.getTime() - targetDate.getTime()
+  const oneDay = 7 * 24 * 60 * 60 * 1000
+
+  return diff >= oneDay
+}


### PR DESCRIPTION
## Feature #131 Enhance build page warning message and labels

## Summary

Add warning message before trigger build when the baseline is expired and add new popover to the snapshots labels

## Changes

- build page
- snapshot detail

## Testing
Warning Message
1. Go to builds
2. Click trigger build
3. If the baseline is more than 7 days ago, it should show a warning message

Popover beside the label
1. Go to build
2. Click the snapshot detail
3. Below the diff tab and approve/reject button click the `info` icon, it should show a popover


## Screenshots
Warning message
<img width="1094" height="470" alt="image" src="https://github.com/user-attachments/assets/4cba2eb1-68af-44b4-b590-095a5a793a05" />

Label info popover
<img width="2760" height="350" alt="image" src="https://github.com/user-attachments/assets/4c446009-0d74-423f-9c16-9e05fbebca6c" />
