### PR TITLE
[SP-130] Add sticky behavior for Approve/Reject buttons and filter bar (v2)

### DIFF
--- a/web/components/ui/scroll-area.tsx
+++ b/web/components/ui/scroll-area.tsx
@@ -10,7 +10,7 @@ function ScrollArea({ className, children, ...props }: React.ComponentProps<type
     <ScrollAreaPrimitive.Root data-slot="scroll-area" className={cn('relative', className)} {...props}>
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full overflow-visible! rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>

--- a/web/features/snapshots/review-content.tsx
+++ b/web/features/snapshots/review-content.tsx
@@ -69,7 +69,7 @@ export function SnapshotReviewContent({
   }
 
   return (
-    <ScrollArea className={cn('h-full', openedSnapshotIds.length && 'h-[98vh]!')}>
+    <ScrollArea className="h-full">
       {snapshotItems.map((snapshot) => {
         const isOpen = openedSnapshotIds.includes(snapshot.id)
 


### PR DESCRIPTION
## Fixes #130 Add sticky behaviour for approve/reject button and filter

## Summary

Add sticky behaviour for the approve/reject button

## Changes

- Snapshots page
- Snapshot detail
- Snapshot element review content

## Testing

- Go to  the snapshots page
- In the scroll area snapshots result, the header and the approve/reject button should be sticky

## Screenshots


<img width="2726" height="956" alt="image" src="https://github.com/user-attachments/assets/c1836f34-fd22-4474-9946-23ce76b007dd" />
